### PR TITLE
feat(schema): Support additionalProperties map schemas

### DIFF
--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -1200,10 +1200,19 @@ Error: \"version\" is a required property"
 
         let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
 
-        assert!(registry.validate_values("test", &json!({"scopes": {}})).is_ok());
-        assert!(registry
-            .validate_values("test", &json!({"scopes": {"read": "true", "write": "false"}}))
-            .is_ok());
+        assert!(
+            registry
+                .validate_values("test", &json!({"scopes": {}}))
+                .is_ok()
+        );
+        assert!(
+            registry
+                .validate_values(
+                    "test",
+                    &json!({"scopes": {"read": "true", "write": "false"}})
+                )
+                .is_ok()
+        );
         assert!(matches!(
             registry.validate_values("test", &json!({"scopes": {"read": 42}})),
             Err(ValidationError::ValueError { .. })

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -391,7 +391,10 @@ impl SchemaRegistry {
 
     /// Inject `required` (all field names) and `additionalProperties: false`
     /// into an object-typed schema. This ensures all properties are required
-    /// and no new properties can be included
+    /// and no new properties can be included.
+    ///
+    /// Skipped when the schema already declares `additionalProperties` explicitly,
+    /// which signals a dynamic map (e.g. `"additionalProperties": {"type": "string"}`).
     /// e.g.
     /// {
     ///     "type": "object",
@@ -405,16 +408,21 @@ impl SchemaRegistry {
     ///     "description": "..."
     /// }
     fn inject_object_constraints(schema: &mut Value) {
-        if let Some(obj) = schema.as_object_mut()
-            && let Some(props) = obj.get("properties").and_then(|p| p.as_object())
-        {
-            let required: Vec<Value> = props
-                .iter()
-                .filter(|(_, v)| !v.get("optional").and_then(|o| o.as_bool()).unwrap_or(false))
-                .map(|(k, _)| Value::String(k.clone()))
-                .collect();
-            obj.insert("required".to_string(), Value::Array(required));
-            obj.insert("additionalProperties".to_string(), json!(false));
+        if let Some(obj) = schema.as_object_mut() {
+            // If additionalProperties is already declared, this is a dynamic map schema.
+            // Do not inject constraints — the schema author controls validation explicitly.
+            if obj.contains_key("additionalProperties") {
+                return;
+            }
+            if let Some(props) = obj.get("properties").and_then(|p| p.as_object()) {
+                let required: Vec<Value> = props
+                    .iter()
+                    .filter(|(_, v)| !v.get("optional").and_then(|o| o.as_bool()).unwrap_or(false))
+                    .map(|(k, _)| Value::String(k.clone()))
+                    .collect();
+                obj.insert("required".to_string(), Value::Array(required));
+                obj.insert("additionalProperties".to_string(), json!(false));
+            }
         }
     }
 
@@ -1173,6 +1181,131 @@ Error: \"version\" is a required property"
             }
             _ => panic!("Expected ValueError for unknown option"),
         }
+    }
+
+    #[test]
+    fn test_object_with_additional_properties_schema_is_valid() {
+        // A property declared as a string→string map must pass schema-file validation.
+        let temp_dir = TempDir::new().unwrap();
+        create_test_schema(
+            &temp_dir,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "scopes": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                        "default": {},
+                        "description": "A dynamic string-to-string map"
+                    }
+                }
+            }"#,
+        );
+
+        assert!(SchemaRegistry::from_directory(temp_dir.path()).is_ok());
+    }
+
+    #[test]
+    fn test_object_with_additional_properties_accepts_valid_map() {
+        // Valid string→string map values must pass value validation.
+        let temp_dir = TempDir::new().unwrap();
+        create_test_schema(
+            &temp_dir,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "scopes": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                        "default": {},
+                        "description": "A dynamic string-to-string map"
+                    }
+                }
+            }"#,
+        );
+
+        let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+
+        // Empty map is valid
+        let result = registry.validate_values("test", &json!({"scopes": {}}));
+        assert!(result.is_ok());
+
+        // Map with string values is valid
+        let result = registry.validate_values(
+            "test",
+            &json!({"scopes": {"read": "true", "write": "false"}}),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_object_with_additional_properties_rejects_wrong_value_type() {
+        // Non-string values in a string map must fail value validation.
+        let temp_dir = TempDir::new().unwrap();
+        create_test_schema(
+            &temp_dir,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "scopes": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                        "default": {},
+                        "description": "A dynamic string-to-string map"
+                    }
+                }
+            }"#,
+        );
+
+        let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+
+        // Integer value where string is expected must fail
+        let result = registry.validate_values("test", &json!({"scopes": {"read": 42}}));
+        assert!(matches!(result, Err(ValidationError::ValueError { .. })));
+    }
+
+    #[test]
+    fn test_object_without_additional_properties_still_rejects_unknown_keys() {
+        // Structured object schemas (with properties, no additionalProperties) must
+        // still reject unknown keys after the fix.
+        let temp_dir = TempDir::new().unwrap();
+        create_test_schema(
+            &temp_dir,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "type": "object",
+                        "properties": {
+                            "host": {"type": "string"}
+                        },
+                        "default": {"host": "localhost"},
+                        "description": "Server config"
+                    }
+                }
+            }"#,
+        );
+
+        let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+
+        // Known key is valid
+        let result = registry.validate_values("test", &json!({"config": {"host": "example.com"}}));
+        assert!(result.is_ok());
+
+        // Unknown key must fail
+        let result = registry.validate_values(
+            "test",
+            &json!({"config": {"host": "example.com", "unknown": "x"}}),
+        );
+        assert!(matches!(result, Err(ValidationError::ValueError { .. })));
     }
 
     #[test]

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -389,12 +389,10 @@ impl SchemaRegistry {
         Ok(())
     }
 
-    /// Inject `required` (all field names) and `additionalProperties: false`
-    /// into an object-typed schema. This ensures all properties are required
-    /// and no new properties can be included.
-    ///
-    /// Skipped when the schema already declares `additionalProperties` explicitly,
-    /// which signals a dynamic map (e.g. `"additionalProperties": {"type": "string"}`).
+    /// Injects `required` (all non-optional field names) into an object-typed schema.
+    /// Also injects `additionalProperties: false` unless the schema already declares
+    /// `additionalProperties` explicitly — that signals a dynamic map where keys are
+    /// not known up front (e.g. `"additionalProperties": {"type": "string"}`).
     /// e.g.
     /// {
     ///     "type": "object",
@@ -409,11 +407,6 @@ impl SchemaRegistry {
     /// }
     fn inject_object_constraints(schema: &mut Value) {
         if let Some(obj) = schema.as_object_mut() {
-            // If additionalProperties is already declared, this is a dynamic map schema.
-            // Do not inject constraints — the schema author controls validation explicitly.
-            if obj.contains_key("additionalProperties") {
-                return;
-            }
             if let Some(props) = obj.get("properties").and_then(|p| p.as_object()) {
                 let required: Vec<Value> = props
                     .iter()
@@ -421,6 +414,8 @@ impl SchemaRegistry {
                     .map(|(k, _)| Value::String(k.clone()))
                     .collect();
                 obj.insert("required".to_string(), Value::Array(required));
+            }
+            if !obj.contains_key("additionalProperties") {
                 obj.insert("additionalProperties".to_string(), json!(false));
             }
         }
@@ -1184,32 +1179,7 @@ Error: \"version\" is a required property"
     }
 
     #[test]
-    fn test_object_with_additional_properties_schema_is_valid() {
-        // A property declared as a string→string map must pass schema-file validation.
-        let temp_dir = TempDir::new().unwrap();
-        create_test_schema(
-            &temp_dir,
-            "test",
-            r#"{
-                "version": "1.0",
-                "type": "object",
-                "properties": {
-                    "scopes": {
-                        "type": "object",
-                        "additionalProperties": {"type": "string"},
-                        "default": {},
-                        "description": "A dynamic string-to-string map"
-                    }
-                }
-            }"#,
-        );
-
-        assert!(SchemaRegistry::from_directory(temp_dir.path()).is_ok());
-    }
-
-    #[test]
-    fn test_object_with_additional_properties_accepts_valid_map() {
-        // Valid string→string map values must pass value validation.
+    fn test_object_with_additional_properties() {
         let temp_dir = TempDir::new().unwrap();
         create_test_schema(
             &temp_dir,
@@ -1230,44 +1200,14 @@ Error: \"version\" is a required property"
 
         let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
 
-        // Empty map is valid
-        let result = registry.validate_values("test", &json!({"scopes": {}}));
-        assert!(result.is_ok());
-
-        // Map with string values is valid
-        let result = registry.validate_values(
-            "test",
-            &json!({"scopes": {"read": "true", "write": "false"}}),
-        );
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_object_with_additional_properties_rejects_wrong_value_type() {
-        // Non-string values in a string map must fail value validation.
-        let temp_dir = TempDir::new().unwrap();
-        create_test_schema(
-            &temp_dir,
-            "test",
-            r#"{
-                "version": "1.0",
-                "type": "object",
-                "properties": {
-                    "scopes": {
-                        "type": "object",
-                        "additionalProperties": {"type": "string"},
-                        "default": {},
-                        "description": "A dynamic string-to-string map"
-                    }
-                }
-            }"#,
-        );
-
-        let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
-
-        // Integer value where string is expected must fail
-        let result = registry.validate_values("test", &json!({"scopes": {"read": 42}}));
-        assert!(matches!(result, Err(ValidationError::ValueError { .. })));
+        assert!(registry.validate_values("test", &json!({"scopes": {}})).is_ok());
+        assert!(registry
+            .validate_values("test", &json!({"scopes": {"read": "true", "write": "false"}}))
+            .is_ok());
+        assert!(matches!(
+            registry.validate_values("test", &json!({"scopes": {"read": 42}})),
+            Err(ValidationError::ValueError { .. })
+        ));
     }
 
     #[test]
@@ -1305,6 +1245,43 @@ Error: \"version\" is a required property"
             "test",
             &json!({"config": {"host": "example.com", "unknown": "x"}}),
         );
+        assert!(matches!(result, Err(ValidationError::ValueError { .. })));
+    }
+
+    #[test]
+    fn test_object_with_fixed_properties_and_additional_properties_enforces_required() {
+        // A schema that has both fixed properties and additionalProperties should still
+        // enforce required on the declared fields.
+        let temp_dir = TempDir::new().unwrap();
+        create_test_schema(
+            &temp_dir,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"}
+                        },
+                        "additionalProperties": {"type": "string"},
+                        "default": {"name": "default"},
+                        "description": "Config with fixed and dynamic keys"
+                    }
+                }
+            }"#,
+        );
+
+        let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+
+        // Fixed field present, extra dynamic keys allowed
+        let result =
+            registry.validate_values("test", &json!({"config": {"name": "x", "extra": "y"}}));
+        assert!(result.is_ok());
+
+        // Missing required fixed field must fail
+        let result = registry.validate_values("test", &json!({"config": {"extra": "y"}}));
         assert!(matches!(result, Err(ValidationError::ValueError { .. })));
     }
 

--- a/sentry-options-validation/src/namespace-schema.json
+++ b/sentry-options-validation/src/namespace-schema.json
@@ -35,6 +35,16 @@
             "description": {
               "type": "string"
             },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": ["string", "integer", "number", "boolean"]
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
             "items": {
               "type": "object",
               "properties": {
@@ -43,6 +53,16 @@
                 },
                 "properties": {
                   "$ref": "#/$defs/shape"
+                },
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": ["string", "integer", "number", "boolean"]
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
                 }
               },
               "required": ["type"],
@@ -54,6 +74,9 @@
                       "type": {
                         "const": "object"
                       }
+                    },
+                    "not": {
+                      "required": ["additionalProperties"]
                     }
                   },
                   "then": {
@@ -87,6 +110,9 @@
                   "type": {
                     "const": "object"
                   }
+                },
+                "not": {
+                  "required": ["additionalProperties"]
                 }
               },
               "then": {
@@ -109,10 +135,20 @@
           "type": "object",
           "properties": {
             "type": {
-              "enum": ["string", "integer", "number", "boolean"]
+              "enum": ["string", "integer", "number", "boolean", "object"]
             },
             "optional": {
               "type": "boolean"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": ["string", "integer", "number", "boolean"]
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
             }
           },
           "required": ["type"],

--- a/sentry-options-validation/src/namespace-schema.json
+++ b/sentry-options-validation/src/namespace-schema.json
@@ -36,14 +36,7 @@
               "type": "string"
             },
             "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "enum": ["string", "integer", "number", "boolean"]
-                }
-              },
-              "required": ["type"],
-              "additionalProperties": false
+              "$ref": "#/$defs/map_value_type"
             },
             "items": {
               "type": "object",
@@ -55,14 +48,7 @@
                   "$ref": "#/$defs/shape"
                 },
                 "additionalProperties": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "enum": ["string", "integer", "number", "boolean"]
-                    }
-                  },
-                  "required": ["type"],
-                  "additionalProperties": false
+                  "$ref": "#/$defs/map_value_type"
                 }
               },
               "required": ["type"],
@@ -128,6 +114,16 @@
   "required": ["version", "type", "properties"],
   "additionalProperties": false,
   "$defs": {
+    "map_value_type": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["string", "integer", "number", "boolean"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
     "shape": {
       "type": "object",
       "patternProperties": {
@@ -141,14 +137,7 @@
               "type": "boolean"
             },
             "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "enum": ["string", "integer", "number", "boolean"]
-                }
-              },
-              "required": ["type"],
-              "additionalProperties": false
+              "$ref": "#/$defs/map_value_type"
             }
           },
           "required": ["type"],

--- a/sentry-options-validation/src/namespace-schema.json
+++ b/sentry-options-validation/src/namespace-schema.json
@@ -141,7 +141,21 @@
             }
           },
           "required": ["type"],
-          "additionalProperties": false
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "object"
+                  }
+                }
+              },
+              "then": {
+                "required": ["additionalProperties"]
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Some options need to represent dynamic key-value mappings rather than fixed-shape objects. A concrete example is a killswitch type with arbitrary scope keys:

```rust
pub struct Killswitch {
    pub scopes: BTreeMap<String, String>,
}
```

Previously, the only way to define an object in a schema was with an explicit `properties` map — every key had to be declared up front. This made it impossible to represent dynamic mappings.

Now, schemas can use `additionalProperties` to describe a map where keys are dynamic but values have a known type:

```json
{
  "scopes": {
    "type": "object",
    "additionalProperties": {
      "type": "string"
    },
    "optional": true
  }
}
```

The validation layer now recognises this pattern and skips the automatic `required`/`additionalProperties: false` injection that would otherwise break it.