### PR TITLE
feat(tracing): Replace println/eprintln with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1540,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1545,6 +1555,8 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -1570,6 +1582,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1666,6 +1679,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1776,6 +1798,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1895,7 +1926,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1905,6 +1948,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2022,6 +2091,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1456,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1461,6 +1471,8 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -1485,6 +1497,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1564,6 +1577,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1677,6 +1699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,12 +1787,24 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1771,6 +1814,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1842,6 +1911,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ sentry = { version = "0.46", default-features = false }
 chrono = "0.4"
 openssl = { version = "0.10", features = ["vendored"] }
 sha1 = "0.10"
+tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ jsonschema = "0.36.0"
 sha1 = "0.10"
 arc-swap = "1.9.1"
 chrono = { version = "0.4.45", default-features = false, features = ["std", "clock"] }
+tracing = "0.1.44"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 sha1.workspace = true
 num = "0.4.3"
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -13,6 +13,7 @@ thiserror.workspace = true
 sha1.workspace = true
 arc-swap.workspace = true
 num = "0.4.3"
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/clients/rust/src/features.rs
+++ b/clients/rust/src/features.rs
@@ -6,7 +6,6 @@
 use num::bigint::{BigInt, Sign};
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
 use serde_json::Value;
 use sha1::{Digest, Sha1};
@@ -345,61 +344,6 @@ fn eval_equals(ctx_val: &Value, condition_val: &Value) -> bool {
     }
 }
 
-#[derive(Debug, PartialEq)]
-enum DebugLogLevel {
-    None,
-    Parse,
-    Match,
-    All,
-}
-
-static DEBUG_LOG_LEVEL: OnceLock<DebugLogLevel> = OnceLock::new();
-static DEBUG_MATCH_SAMPLE_RATE: OnceLock<u64> = OnceLock::new();
-
-fn debug_log_level() -> &'static DebugLogLevel {
-    DEBUG_LOG_LEVEL.get_or_init(|| {
-        match std::env::var("SENTRY_OPTIONS_FEATURE_DEBUG_LOG")
-            .as_deref()
-            .unwrap_or("")
-        {
-            "all" => DebugLogLevel::All,
-            "parse" => DebugLogLevel::Parse,
-            "match" => DebugLogLevel::Match,
-            _ => DebugLogLevel::None,
-        }
-    })
-}
-
-fn debug_match_sample_rate() -> u64 {
-    *DEBUG_MATCH_SAMPLE_RATE.get_or_init(|| {
-        std::env::var("SENTRY_OPTIONS_FEATURE_DEBUG_LOG_SAMPLE_RATE")
-            .ok()
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|r| (r.clamp(0.0, 1.0) * 1000.0) as u64)
-            .unwrap_or(1000)
-    })
-}
-
-fn debug_log_parse(msg: &str) {
-    match debug_log_level() {
-        DebugLogLevel::Parse | DebugLogLevel::All => eprintln!("[sentry-options/parse] {msg}"),
-        _ => {}
-    }
-}
-
-fn debug_log_match(feature: &str, result: bool, context_id: u64) {
-    match debug_log_level() {
-        DebugLogLevel::Match | DebugLogLevel::All => {
-            if context_id % 1000 < debug_match_sample_rate() {
-                eprintln!(
-                    "[sentry-options/match] feature='{feature}' result={result} context_id={context_id}"
-                );
-            }
-        }
-        _ => {}
-    }
-}
-
 /// A handle for checking feature flags within a specific namespace.
 pub struct FeatureChecker {
     namespace: String,
@@ -427,24 +371,29 @@ impl FeatureChecker {
         let feature_val = match opts.get(&self.namespace, &key) {
             Ok(v) => v,
             Err(e) => {
-                debug_log_parse(&format!("Failed to get feature '{key}': {e}"));
+                tracing::debug!(key = %key, error = %e, "Failed to get feature");
                 return false;
             }
         };
 
         let feature = match Feature::from_json(&feature_val) {
             Some(f) => {
-                debug_log_parse(&format!("Parsed feature '{key}'"));
+                tracing::debug!(key = %key, "Parsed feature");
                 f
             }
             None => {
-                debug_log_parse(&format!("Failed to parse feature '{key}'"));
+                tracing::debug!(key = %key, "Failed to parse feature");
                 return false;
             }
         };
 
         let result = feature.matches(context);
-        debug_log_match(feature_name, result, context.id());
+        tracing::debug!(
+            feature = feature_name,
+            result,
+            context_id = context.id(),
+            "Feature match result"
+        );
         result
     }
 }

--- a/clients/rust/src/features.rs
+++ b/clients/rust/src/features.rs
@@ -6,7 +6,6 @@
 use num::bigint::{BigInt, Sign};
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
 use serde_json::Value;
 use sha1::{Digest, Sha1};
@@ -412,61 +411,6 @@ fn eval_matches(ctx_val: &Value, condition_val: &Value) -> bool {
     })
 }
 
-#[derive(Debug, PartialEq)]
-enum DebugLogLevel {
-    None,
-    Parse,
-    Match,
-    All,
-}
-
-static DEBUG_LOG_LEVEL: OnceLock<DebugLogLevel> = OnceLock::new();
-static DEBUG_MATCH_SAMPLE_RATE: OnceLock<u64> = OnceLock::new();
-
-fn debug_log_level() -> &'static DebugLogLevel {
-    DEBUG_LOG_LEVEL.get_or_init(|| {
-        match std::env::var("SENTRY_OPTIONS_FEATURE_DEBUG_LOG")
-            .as_deref()
-            .unwrap_or("")
-        {
-            "all" => DebugLogLevel::All,
-            "parse" => DebugLogLevel::Parse,
-            "match" => DebugLogLevel::Match,
-            _ => DebugLogLevel::None,
-        }
-    })
-}
-
-fn debug_match_sample_rate() -> u64 {
-    *DEBUG_MATCH_SAMPLE_RATE.get_or_init(|| {
-        std::env::var("SENTRY_OPTIONS_FEATURE_DEBUG_LOG_SAMPLE_RATE")
-            .ok()
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|r| (r.clamp(0.0, 1.0) * 1000.0) as u64)
-            .unwrap_or(1000)
-    })
-}
-
-fn debug_log_parse(msg: &str) {
-    match debug_log_level() {
-        DebugLogLevel::Parse | DebugLogLevel::All => eprintln!("[sentry-options/parse] {msg}"),
-        _ => {}
-    }
-}
-
-fn debug_log_match(feature: &str, result: bool, context_id: u64) {
-    match debug_log_level() {
-        DebugLogLevel::Match | DebugLogLevel::All
-            if context_id % 1000 < debug_match_sample_rate() =>
-        {
-            eprintln!(
-                "[sentry-options/match] feature='{feature}' result={result} context_id={context_id}"
-            );
-        }
-        _ => {}
-    }
-}
-
 /// A handle for checking feature flags within a specific namespace.
 pub struct FeatureChecker {
     namespace: String,
@@ -494,24 +438,29 @@ impl FeatureChecker {
         let feature_val = match opts.get(&self.namespace, &key) {
             Ok(v) => v,
             Err(e) => {
-                debug_log_parse(&format!("Failed to get feature '{key}': {e}"));
+                tracing::debug!(key = %key, error = %e, "Failed to get feature");
                 return false;
             }
         };
 
         let feature = match Feature::from_json(&feature_val) {
             Some(f) => {
-                debug_log_parse(&format!("Parsed feature '{key}'"));
+                tracing::debug!(key = %key, "Parsed feature");
                 f
             }
             None => {
-                debug_log_parse(&format!("Failed to parse feature '{key}'"));
+                tracing::debug!(key = %key, "Failed to parse feature");
                 return false;
             }
         };
 
         let result = feature.matches(context);
-        debug_log_match(feature_name, result, context.id());
+        tracing::debug!(
+            feature = feature_name,
+            result,
+            context_id = context.id(),
+            "Feature match result"
+        );
         result
     }
 }

--- a/sentry-options-cli/Cargo.toml
+++ b/sentry-options-cli/Cargo.toml
@@ -16,6 +16,8 @@ sentry-options-validation.workspace = true
 thiserror.workspace = true
 walkdir = "2.5.0"
 tempfile.workspace = true
+tracing.workspace = true
+tracing-subscriber = { version = "0.3.19", features = ["fmt"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sentry-options-cli/Cargo.toml
+++ b/sentry-options-cli/Cargo.toml
@@ -16,6 +16,8 @@ sentry-options-validation.workspace = true
 thiserror.workspace = true
 walkdir = "2.5.0"
 tempfile.workspace = true
+tracing.workspace = true
+tracing-subscriber = { version = "0.3.23", features = ["fmt"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sentry-options-cli/src/main.rs
+++ b/sentry-options-cli/src/main.rs
@@ -218,7 +218,7 @@ fn cli_validate_schema(schemas: String, quiet: bool) -> Result<()> {
     SchemaRegistry::from_directory(Path::new(&schemas))?;
 
     if !quiet {
-        println!("Schema validation successful");
+        tracing::info!("Schema validation successful");
     }
     Ok(())
 }
@@ -229,7 +229,7 @@ fn cli_validate_values(schemas: String, root: String, quiet: bool) -> Result<()>
     ensure_no_duplicate_keys(&grouped)?;
 
     if !quiet {
-        println!("Values validation successful");
+        tracing::info!("Values validation successful");
     }
     Ok(())
 }
@@ -252,7 +252,7 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
             write_json(PathBuf::from(&out_path), json_outputs)?;
 
             if !quiet {
-                println!("Successfully wrote {} output files", num_files);
+                tracing::info!(num_files, "Successfully wrote output files");
             }
         }
         OutputFormat::Configmap => {
@@ -276,11 +276,12 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
 
             if !quiet {
                 match out_path {
-                    Some(path) => eprintln!("Successfully wrote ConfigMap to {}", path.display()),
-                    None => eprintln!(
-                        "Successfully generated ConfigMap: sentry-options-{}",
-                        namespace
-                    ),
+                    Some(path) => {
+                        tracing::info!(path = %path.display(), "Successfully wrote ConfigMap")
+                    }
+                    None => {
+                        tracing::info!(name = %format!("sentry-options-{namespace}"), "Successfully generated ConfigMap")
+                    }
                 }
             }
         }
@@ -292,7 +293,7 @@ fn cli_fetch_schemas(config: String, out: String, quiet: bool) -> Result<()> {
     let config = repo_schema_config::RepoSchemaConfigs::from_file(Path::new(&config))?;
     schema_retriever::fetch_all_schemas(&config, Path::new(&out), quiet)?;
     if !quiet {
-        println!("Successfully fetched schemas to {}", out);
+        tracing::info!(path = %out, "Successfully fetched schemas");
     }
     Ok(())
 }
@@ -329,7 +330,7 @@ fn cli_validate_schema_changes(
     )?;
 
     if !quiet {
-        eprintln!("Schema validation passed");
+        tracing::info!("Schema validation passed");
     }
 
     Ok(())
@@ -342,6 +343,12 @@ fn cli_check_option_usage(deletions: String, root: String) -> Result<()> {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .compact()
+        .without_time()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
     let cli = Cli::parse();
 
     let result = match cli.command {
@@ -359,7 +366,7 @@ fn main() {
     };
 
     if let Err(e) = result {
-        eprintln!("{}", e);
+        tracing::error!(error = %e);
         std::process::exit(1);
     }
 }

--- a/sentry-options-cli/src/main.rs
+++ b/sentry-options-cli/src/main.rs
@@ -224,7 +224,7 @@ fn cli_validate_schema(schemas: String, quiet: bool) -> Result<()> {
     SchemaRegistry::from_directory(Path::new(&schemas))?;
 
     if !quiet {
-        println!("Schema validation successful");
+        tracing::info!("Schema validation successful");
     }
     Ok(())
 }
@@ -235,7 +235,7 @@ fn cli_validate_values(schemas: String, root: String, quiet: bool) -> Result<()>
     ensure_no_duplicate_keys(&grouped)?;
 
     if !quiet {
-        println!("Values validation successful");
+        tracing::info!("Values validation successful");
     }
     Ok(())
 }
@@ -258,7 +258,7 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
             write_json(PathBuf::from(&out_path), json_outputs)?;
 
             if !quiet {
-                println!("Successfully wrote {} output files", num_files);
+                tracing::info!(num_files, "Successfully wrote output files");
             }
         }
         OutputFormat::Configmap => {
@@ -283,8 +283,12 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
 
             if !quiet {
                 match out_path {
-                    Some(path) => eprintln!("Successfully wrote ConfigMap to {}", path.display()),
-                    None => eprintln!("Successfully generated ConfigMap: {}", configmap.name()),
+                    Some(path) => {
+                        tracing::info!(path = %path.display(), "Successfully wrote ConfigMap")
+                    }
+                    None => {
+                        tracing::info!(name = %configmap.name(), "Successfully generated ConfigMap")
+                    }
                 }
             }
         }
@@ -296,7 +300,7 @@ fn cli_fetch_schemas(config: String, out: String, quiet: bool) -> Result<()> {
     let config = repo_schema_config::RepoSchemaConfigs::from_file(Path::new(&config))?;
     schema_retriever::fetch_all_schemas(&config, Path::new(&out), quiet)?;
     if !quiet {
-        println!("Successfully fetched schemas to {}", out);
+        tracing::info!(path = %out, "Successfully fetched schemas");
     }
     Ok(())
 }
@@ -333,7 +337,7 @@ fn cli_validate_schema_changes(
     )?;
 
     if !quiet {
-        eprintln!("Schema validation passed");
+        tracing::info!("Schema validation passed");
     }
 
     Ok(())
@@ -346,6 +350,16 @@ fn cli_check_option_usage(deletions: String, root: String) -> Result<()> {
 }
 
 fn main() {
+    // Logs go to stderr so that command output on stdout stays machine-readable:
+    // CI captures `validate-schema-changes --report-deletions` and
+    // `check-option-usage` stdout directly into shell variables.
+    tracing_subscriber::fmt()
+        .compact()
+        .without_time()
+        .with_writer(std::io::stderr)
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
     let cli = Cli::parse();
 
     let result = match cli.command {
@@ -363,7 +377,7 @@ fn main() {
     };
 
     if let Err(e) = result {
-        eprintln!("{}", e);
+        tracing::error!(error = %e, "Command failed");
         std::process::exit(1);
     }
 }

--- a/sentry-options-cli/src/schema_evolution.rs
+++ b/sentry-options-cli/src/schema_evolution.rs
@@ -304,19 +304,18 @@ pub fn detect_changes(
     }
 
     if !quiet {
-        eprintln!("Schema Changes:");
         if changelog.is_empty() {
-            eprintln!("\tNo changes");
-        }
-        for change in &changelog {
-            eprintln!("\t{}", change);
+            tracing::info!("No schema changes");
+        } else {
+            for change in &changelog {
+                tracing::info!(%change, "Schema change detected");
+            }
         }
     }
 
     if !errors.is_empty() {
-        println!("Errors:");
         for error in &errors {
-            println!("\t{}", error);
+            tracing::error!(%error, "Schema validation error");
         }
         return Err(ValidationError::ValidationErrors(errors));
     }

--- a/sentry-options-cli/src/schema_retriever.rs
+++ b/sentry-options-cli/src/schema_retriever.rs
@@ -22,7 +22,7 @@ pub fn fetch_all_schemas(config: &RepoSchemaConfigs, out_dir: &Path, quiet: bool
     repo_names.sort();
 
     if !quiet {
-        println!("Fetching schemas...");
+        tracing::info!("Fetching schemas");
     }
 
     // Fetch all repos in parallel, collecting results
@@ -58,7 +58,7 @@ pub fn fetch_all_schemas(config: &RepoSchemaConfigs, out_dir: &Path, quiet: bool
         match result {
             Ok(()) => {
                 if !quiet {
-                    println!("  Fetched {}", repo_name);
+                    tracing::info!(repo = repo_name, "Fetched schema");
                 }
             }
             Err(e) => errors.push(e),

--- a/sentry-options-cli/src/schema_retriever.rs
+++ b/sentry-options-cli/src/schema_retriever.rs
@@ -22,7 +22,7 @@ pub fn fetch_all_schemas(config: &RepoSchemaConfigs, out_dir: &Path, quiet: bool
     repo_names.sort();
 
     if !quiet {
-        println!("Fetching schemas...");
+        tracing::info!("Fetching schemas");
     }
 
     // Fetch all repos in parallel, collecting results
@@ -58,7 +58,7 @@ pub fn fetch_all_schemas(config: &RepoSchemaConfigs, out_dir: &Path, quiet: bool
         match result {
             Ok(()) => {
                 if !quiet {
-                    println!("  Fetched {}", repo_name);
+                    tracing::info!(repo = repo_name, "Fetched schema");
                 }
             }
             Err(e) => errors.push(e),
@@ -136,7 +136,7 @@ fn try_fetch_repo_schemas(
         let sha = String::from_utf8_lossy(&rev_output.stdout)
             .trim()
             .to_string();
-        eprintln!("  {} cloned at sha: {}", repo_name, sha);
+        tracing::info!(repo = repo_name, %sha, "Cloned repo");
     }
 
     copy_schemas(&repo_path.join(&source.path), out_dir)?;

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -16,9 +16,7 @@ tempfile.workspace = true
 sentry = { workspace = true, features = ["transport"] }
 chrono.workspace = true
 openssl.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-
-[features]
-default = []

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -15,9 +15,7 @@ jsonschema.workspace = true
 tempfile.workspace = true
 arc-swap.workspace = true
 chrono.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-
-[features]
-default = []

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -596,7 +596,7 @@ impl ValuesWatcher {
     ) -> ValidationResult<Self> {
         // output an error but keep passing
         if !should_suppress_missing_dir_errors() && fs::metadata(values_path).is_err() {
-            eprintln!("Values directory does not exist: {}", values_path.display());
+            tracing::warn!(path = %values_path.display(), "Values directory does not exist");
         }
 
         let stop_signal = Arc::new(AtomicBool::new(false));
@@ -612,7 +612,7 @@ impl ValuesWatcher {
                     Self::run(thread_signal, thread_path, thread_registry, thread_values);
                 }));
                 if let Err(e) = result {
-                    eprintln!("Watcher thread panicked with: {:?}", e);
+                    tracing::error!(error = ?e, "Watcher thread panicked");
                 }
             })?;
 
@@ -656,7 +656,7 @@ impl ValuesWatcher {
             Ok(e) => e,
             Err(e) => {
                 if !should_suppress_missing_dir_errors() {
-                    eprintln!("Failed to read directory {}: {}", values_dir.display(), e);
+                    tracing::warn!(dir = %values_dir.display(), error = %e, "Failed to read directory");
                 }
                 return None;
             }
@@ -699,14 +699,16 @@ impl ValuesWatcher {
                 Self::update_values(values, new_values);
 
                 let reload_duration = reload_start.elapsed();
+                tracing::info!(
+                    path = %values_path.display(),
+                    namespaces = ?namespaces,
+                    elapsed_ms = reload_duration.as_millis(),
+                    "Reloaded values",
+                );
                 Self::emit_reload_spans(&namespaces, reload_duration, &generated_at_by_namespace);
             }
             Err(e) => {
-                eprintln!(
-                    "Failed to reload values from {}: {}",
-                    values_path.display(),
-                    e
-                );
+                tracing::error!(path = %values_path.display(), error = %e, "Failed to reload values");
             }
         }
     }

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -611,10 +611,11 @@ impl SchemaRegistry {
         }
 
         for key in &unknown_keys {
-            eprintln!(
-                "sentry-options: Ignoring unknown option '{}' in namespace '{}'. \
-                 This is expected during deployments when values are updated before schemas.",
-                key, namespace
+            tracing::warn!(
+                key = %key,
+                namespace = %namespace,
+                "Ignoring unknown option. This is expected during deployments when \
+                 values are updated before schemas.",
             );
         }
 
@@ -693,7 +694,7 @@ impl ValuesStoreBuilder {
     pub fn build(self) -> ValidationResult<ValuesStore> {
         let values_dir = &self.values_dir;
         if !should_suppress_missing_dir_errors() && fs::metadata(values_dir).is_err() {
-            eprintln!("Values directory does not exist: {}", values_dir.display());
+            tracing::warn!(path = %values_dir.display(), "Values directory does not exist");
         }
 
         let baseline = Instant::now();
@@ -826,10 +827,10 @@ impl ValuesStore {
     }
 
     fn log_refresh_error(&self, error: &ValidationError) {
-        eprintln!(
-            "Failed to reload values from {}: {}",
-            self.values_dir.display(),
-            error
+        tracing::error!(
+            path = %self.values_dir.display(),
+            error = %error,
+            "Failed to reload values",
         );
     }
 
@@ -845,6 +846,7 @@ impl ValuesStore {
             return Ok(false);
         }
 
+        let reload_start = Instant::now();
         let result = self.registry.load_values_json(&self.values_dir);
 
         // Publish the new snapshot before bumping the timestamp. The CAS below
@@ -856,6 +858,16 @@ impl ValuesStore {
         // architectures.
         let new_generated_at = match result {
             Ok((new_values, generated_at)) => {
+                let elapsed_ms = reload_start.elapsed().as_millis();
+                for namespace in new_values.keys() {
+                    tracing::info!(
+                        path = %self.values_dir.display(),
+                        namespace = %namespace,
+                        elapsed_ms,
+                        "Reloaded values",
+                    );
+                }
+
                 self.values.store(Arc::new(new_values));
                 self.last_mtimes.store(Arc::new(current_mtimes));
                 Ok(generated_at)
@@ -894,10 +906,18 @@ impl ValuesStore {
                                     callback(ns, delay)
                                 }))
                             {
-                                eprintln!("Propagation callback panicked for {ns}: {:?}", e);
+                                tracing::error!(
+                                    namespace = %ns,
+                                    error = ?e,
+                                    "Propagation callback panicked",
+                                );
                             }
                         }
-                        None => eprintln!("Bad generated_at for {ns}: {ts}"),
+                        None => tracing::warn!(
+                            namespace = %ns,
+                            generated_at = %ts,
+                            "Bad generated_at timestamp",
+                        ),
                     }
                 }
             }


### PR DESCRIPTION
Applications embedding `sentry-options` as a dependency may have their own logging sinks — a Sentry SDK, a structured log aggregator, or similar. Hard-coded `eprintln`/`println` bypasses those sinks entirely.

By emitting events through the [`tracing`](https://docs.rs/tracing) crate, the host application controls how and where they are captured. The CLI gets a compact, time-free `tracing-subscriber` at INFO level so its own output is unaffected.