### PR TITLE
feat(watcher): Fork-safe, PID-aware values watcher

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -76,13 +76,13 @@ impl Options {
         Ok(Self {
             registry,
             values,
-            watcher: watcher,
+            watcher,
         })
     }
 
     /// Get an option value, returning the schema default if not set.
     pub fn get(&self, namespace: &str, key: &str) -> Result<Value> {
-        self.watcher.compare_pid();
+        self.watcher.ensure_alive();
         if let Some(value) = testing::get_override(namespace, key) {
             return Ok(value);
         }
@@ -130,7 +130,7 @@ impl Options {
     ///
     /// If the namespace or option are not defined, an Err will be returned.
     pub fn isset(&self, namespace: &str, key: &str) -> Result<bool> {
-        self.watcher.compare_pid();
+        self.watcher.ensure_alive();
         let schema = self
             .registry
             .get(namespace)

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -39,7 +39,7 @@ pub type Result<T> = std::result::Result<T, OptionsError>;
 pub struct Options {
     registry: Arc<SchemaRegistry>,
     values: Arc<RwLock<HashMap<String, HashMap<String, Value>>>>,
-    _watcher: ValuesWatcher,
+    watcher: ValuesWatcher,
 }
 
 impl Options {
@@ -68,16 +68,21 @@ impl Options {
         let registry = Arc::new(registry);
         let (loaded_values, _) = registry.load_values_json(values_dir)?;
         let values = Arc::new(RwLock::new(loaded_values));
-        let watcher = ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values))?;
+        let watcher = ValuesWatcher::new(
+            values_dir.to_path_buf(),
+            Arc::clone(&registry),
+            Arc::clone(&values),
+        )?;
         Ok(Self {
             registry,
             values,
-            _watcher: watcher,
+            watcher: watcher,
         })
     }
 
     /// Get an option value, returning the schema default if not set.
     pub fn get(&self, namespace: &str, key: &str) -> Result<Value> {
+        self.watcher.compare_pid();
         if let Some(value) = testing::get_override(namespace, key) {
             return Ok(value);
         }
@@ -125,6 +130,7 @@ impl Options {
     ///
     /// If the namespace or option are not defined, an Err will be returned.
     pub fn isset(&self, namespace: &str, key: &str) -> Result<bool> {
+        self.watcher.compare_pid();
         let schema = self
             .registry
             .get(namespace)

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -13,7 +13,10 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::process;
+use std::sync::Mutex;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicU32;
 use std::sync::{
     Arc, OnceLock,
     atomic::{AtomicBool, Ordering},
@@ -628,19 +631,78 @@ impl Default for SchemaRegistry {
 ///
 /// Uses polling for now, could use `inotify` or similar later on.
 ///
+/// This thread will not be copied when a parent process is forked, so we track the initial PID
+/// and recreate the thread handle if it doesn't match the current process PID.
+///
 /// Some important notes:
 /// - If the thread panics and dies, there is no built in mechanism to catch it and restart
 /// - If a config map is unmounted, we won't reload until the next file modification (because we don't catch the deletion event)
 /// - If any namespace fails validation, we keep all old values (even the namespaces that passed validation)
 /// - If we have a steady stream of readers our writer may starve for a while trying to acquire the lock
-/// - stop() will block until the thread gets joined
+/// - stop() does not wait for the thread to join
 pub struct ValuesWatcher {
+    pid: AtomicU32,
+    values_path: PathBuf,
+    registry: Arc<SchemaRegistry>,
+    values: Arc<RwLock<ValuesByNamespace>>,
+    watcher: Mutex<ValuesWatcherThread>,
+}
+
+impl ValuesWatcher {
+    pub fn new(
+        values_path: PathBuf,
+        registry: Arc<SchemaRegistry>,
+        values: Arc<RwLock<ValuesByNamespace>>,
+    ) -> ValidationResult<Self> {
+        let pid = AtomicU32::new(process::id());
+        let watcher = Mutex::new(ValuesWatcherThread::new(
+            &values_path,
+            Arc::clone(&registry),
+            Arc::clone(&values),
+        )?);
+        Ok(Self {
+            pid,
+            values_path,
+            registry,
+            values,
+            watcher,
+        })
+    }
+
+    /// Re-creates the value watcher thread with the same arguments in a
+    /// thread-safe manner. Handles updating the PID and stopping the old thread.
+    fn respawn(&self) -> ValidationResult<()> {
+        let mut guard = self.watcher.lock().unwrap_or_else(|e| e.into_inner());
+        self.pid.store(process::id(), Ordering::Relaxed);
+        guard.stop();
+        let watcher = ValuesWatcherThread::new(
+            &self.values_path,
+            Arc::clone(&self.registry),
+            Arc::clone(&self.values),
+        )?;
+        *guard = watcher;
+        Ok(())
+    }
+
+    /// Compares the current and stored PID. If they differ, we
+    /// are likely in a forked process and need to recreate the thread.
+    pub fn compare_pid(&self) -> ValidationResult<()> {
+        if self.pid.load(Ordering::Relaxed) != process::id() {
+            self.respawn()?;
+        }
+        Ok(())
+    }
+}
+
+/// The actual value watcher thread struct, containing the
+/// thread handle and cancellation signal.
+pub struct ValuesWatcherThread {
     stop_signal: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
 }
 
-impl ValuesWatcher {
-    /// Creates a new ValuesWatcher struct and spins up the watcher thread
+impl ValuesWatcherThread {
+    /// Creates a new ValuesWatcherThread and spins up the watcher thread
     pub fn new(
         values_path: &Path,
         registry: Arc<SchemaRegistry>,
@@ -804,13 +866,9 @@ impl ValuesWatcher {
         *guard = new_values;
     }
 
-    /// Stops the watcher thread, waiting for it to join.
-    /// May take up to POLLING_DELAY seconds
+    /// Stops the watcher thread without waiting for it to join
     pub fn stop(&mut self) {
         self.stop_signal.store(true, Ordering::Relaxed);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
     }
 
     /// Returns whether the watcher thread is still running
@@ -819,7 +877,7 @@ impl ValuesWatcher {
     }
 }
 
-impl Drop for ValuesWatcher {
+impl Drop for ValuesWatcherThread {
     fn drop(&mut self) {
         self.stop();
     }
@@ -1928,7 +1986,7 @@ Error: \"version\" is a required property"
             let (_temp, _schemas, values_dir) = setup_watcher_test();
 
             // Get initial mtime
-            let mtime1 = ValuesWatcher::get_mtime(&values_dir);
+            let mtime1 = ValuesWatcherThread::get_mtime(&values_dir);
             assert!(mtime1.is_some());
 
             // Modify one namespace
@@ -1940,7 +1998,7 @@ Error: \"version\" is a required property"
             .unwrap();
 
             // Should detect the change
-            let mtime2 = ValuesWatcher::get_mtime(&values_dir);
+            let mtime2 = ValuesWatcherThread::get_mtime(&values_dir);
             assert!(mtime2.is_some());
             assert!(mtime2 > mtime1);
         }
@@ -1950,7 +2008,7 @@ Error: \"version\" is a required property"
             let temp = TempDir::new().unwrap();
             let nonexistent = temp.path().join("nonexistent");
 
-            let mtime = ValuesWatcher::get_mtime(&nonexistent);
+            let mtime = ValuesWatcherThread::get_mtime(&nonexistent);
             assert!(mtime.is_none());
         }
 
@@ -1982,7 +2040,7 @@ Error: \"version\" is a required property"
             .unwrap();
 
             // force a reload
-            ValuesWatcher::reload_values(&values_dir, &registry, &values);
+            ValuesWatcherThread::reload_values(&values_dir, &registry, &values);
 
             // ensure new values are correct
             {
@@ -2012,7 +2070,7 @@ Error: \"version\" is a required property"
             )
             .unwrap();
 
-            ValuesWatcher::reload_values(&values_dir, &registry, &values);
+            ValuesWatcherThread::reload_values(&values_dir, &registry, &values);
 
             // ensure old value persists
             {
@@ -2030,11 +2088,15 @@ Error: \"version\" is a required property"
             let values = Arc::new(RwLock::new(initial_values));
 
             let mut watcher =
-                ValuesWatcher::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
+                ValuesWatcherThread::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
                     .expect("Failed to create watcher");
 
             assert!(watcher.is_alive());
             watcher.stop();
+            // we don't join in watcher.stop() anymore, so we need to join here to prove it's working
+            if let Some(t) = watcher.thread.take() {
+                t.join().unwrap();
+            }
             assert!(!watcher.is_alive());
         }
     }

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -2206,41 +2206,6 @@ Error: \"version\" is a required property"
                 assert_eq!(guard["ns1"]["enabled"], json!(false));
             }
         }
-
-        #[test]
-        fn test_respawn_skipped_if_another_thread_already_respawned() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
-
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
-
-            let watcher = Arc::new(
-                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap(),
-            );
-
-            // Simulate a fork
-            watcher.pid.store(0, Ordering::Relaxed);
-
-            // Call ensure_alive from multiple threads concurrently
-            let handles: Vec<_> = (0..4)
-                .map(|_| {
-                    let w = Arc::clone(&watcher);
-                    thread::spawn(move || {
-                        w.ensure_alive();
-                    })
-                })
-                .collect();
-
-            for h in handles {
-                h.join().unwrap();
-            }
-
-            // PID should be restored, watcher should be alive
-            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
-            let guard = watcher.watcher.lock().unwrap();
-            assert!(guard.is_alive());
-        }
     }
     mod array_tests {
         use super::*;

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -639,7 +639,7 @@ impl Default for SchemaRegistry {
 /// - If a config map is unmounted, we won't reload until the next file modification (because we don't catch the deletion event)
 /// - If any namespace fails validation, we keep all old values (even the namespaces that passed validation)
 /// - If we have a steady stream of readers our writer may starve for a while trying to acquire the lock
-/// - stop() does not wait for the thread to join
+/// - On drop, the thread is joined only if PID matches (skipped in forked processes)
 pub struct ValuesWatcher {
     pid: AtomicU32,
     values_path: PathBuf,
@@ -671,6 +671,7 @@ impl ValuesWatcher {
 
     /// Re-creates the value watcher thread with the same arguments in a
     /// thread-safe manner. Handles updating the PID and stopping the old thread.
+    /// Force reloads values so the child process has fresh data.
     fn respawn(&self) -> ValidationResult<()> {
         let mut guard = self.watcher.lock().unwrap_or_else(|e| e.into_inner());
         // just in case another thread has called this already
@@ -685,6 +686,12 @@ impl ValuesWatcher {
             Arc::clone(&self.values),
         )?;
         *guard = watcher;
+
+        // Force reload values so the new watcher thread's mtime baseline
+        // is consistent with what's in memory. Without this, the child
+        // process could have stale values if the file changed since the fork.
+        ValuesWatcherThread::reload_values(&self.values_path, &self.registry, &self.values);
+
         Ok(())
     }
 
@@ -706,6 +713,7 @@ impl ValuesWatcher {
 /// The actual value watcher thread struct, containing the
 /// thread handle and cancellation signal.
 pub struct ValuesWatcherThread {
+    pid: u32,
     stop_signal: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
 }
@@ -740,6 +748,7 @@ impl ValuesWatcherThread {
             })?;
 
         Ok(Self {
+            pid: process::id(),
             stop_signal,
             thread: Some(thread),
         })
@@ -809,7 +818,7 @@ impl ValuesWatcherThread {
 
     /// Reload values from disk, validate them, and update the shared map.
     /// Emits a Sentry transaction per namespace with timing and propagation delay metrics.
-    fn reload_values(
+    pub(crate) fn reload_values(
         values_path: &Path,
         registry: &SchemaRegistry,
         values: &Arc<RwLock<ValuesByNamespace>>,
@@ -875,9 +884,16 @@ impl ValuesWatcherThread {
         *guard = new_values;
     }
 
-    /// Stops the watcher thread without waiting for it to join
+    /// Signals the watcher thread to stop
     pub fn stop(&mut self) {
         self.stop_signal.store(true, Ordering::Relaxed);
+    }
+
+    /// Joins the watcher thread, blocking until it finishes
+    fn join(&mut self) {
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
     }
 
     /// Returns whether the watcher thread is still running
@@ -889,6 +905,12 @@ impl ValuesWatcherThread {
 impl Drop for ValuesWatcherThread {
     fn drop(&mut self) {
         self.stop();
+        // Only join if we're in the same process that created the thread.
+        // In a forked child, the thread handle is invalid (the thread
+        // wasn't copied), so joining would be incorrect.
+        if self.pid == process::id() {
+            self.join();
+        }
     }
 }
 
@@ -2102,11 +2124,122 @@ Error: \"version\" is a required property"
 
             assert!(watcher.is_alive());
             watcher.stop();
-            // we don't join in watcher.stop() anymore, so we need to join here to prove it's working
-            if let Some(t) = watcher.thread.take() {
-                t.join().unwrap();
-            }
+            watcher.join();
             assert!(!watcher.is_alive());
+        }
+
+        #[test]
+        fn test_ensure_alive_noop_when_pid_matches() {
+            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
+            let values = Arc::new(RwLock::new(initial_values));
+
+            let watcher =
+                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
+
+            // PID matches, ensure_alive should be a no-op
+            watcher.ensure_alive();
+            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
+        }
+
+        #[test]
+        fn test_ensure_alive_respawns_on_pid_mismatch() {
+            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
+            let values = Arc::new(RwLock::new(initial_values));
+
+            let watcher =
+                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
+
+            // Simulate a fork by setting the stored PID to something different
+            watcher.pid.store(0, Ordering::Relaxed);
+
+            watcher.ensure_alive();
+
+            // After respawn, stored PID should match current process
+            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
+
+            // The new watcher thread should be alive
+            let guard = watcher.watcher.lock().unwrap();
+            assert!(guard.is_alive());
+        }
+
+        #[test]
+        fn test_respawn_reloads_values_from_disk() {
+            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
+            let values = Arc::new(RwLock::new(initial_values));
+
+            let watcher = ValuesWatcher::new(
+                values_dir.clone(),
+                Arc::clone(&registry),
+                Arc::clone(&values),
+            )
+            .unwrap();
+
+            // Verify initial values
+            {
+                let guard = values.read().unwrap();
+                assert_eq!(guard["ns1"]["enabled"], json!(true));
+            }
+
+            // Change values on disk
+            fs::write(
+                values_dir.join("ns1").join("values.json"),
+                r#"{"options": {"enabled": false}}"#,
+            )
+            .unwrap();
+
+            // Simulate a fork and trigger respawn
+            watcher.pid.store(0, Ordering::Relaxed);
+            watcher.ensure_alive();
+
+            // Values should be reloaded from disk
+            {
+                let guard = values.read().unwrap();
+                assert_eq!(guard["ns1"]["enabled"], json!(false));
+            }
+        }
+
+        #[test]
+        fn test_respawn_skipped_if_another_thread_already_respawned() {
+            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
+            let values = Arc::new(RwLock::new(initial_values));
+
+            let watcher = Arc::new(
+                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap(),
+            );
+
+            // Simulate a fork
+            watcher.pid.store(0, Ordering::Relaxed);
+
+            // Call ensure_alive from multiple threads concurrently
+            let handles: Vec<_> = (0..4)
+                .map(|_| {
+                    let w = Arc::clone(&watcher);
+                    thread::spawn(move || {
+                        w.ensure_alive();
+                    })
+                })
+                .collect();
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            // PID should be restored, watcher should be alive
+            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
+            let guard = watcher.watcher.lock().unwrap();
+            assert!(guard.is_alive());
         }
     }
     mod array_tests {

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -673,6 +673,10 @@ impl ValuesWatcher {
     /// thread-safe manner. Handles updating the PID and stopping the old thread.
     fn respawn(&self) -> ValidationResult<()> {
         let mut guard = self.watcher.lock().unwrap_or_else(|e| e.into_inner());
+        // just in case another thread has called this already
+        if self.pid.load(Ordering::Relaxed) == process::id() {
+            return Ok(());
+        }
         self.pid.store(process::id(), Ordering::Relaxed);
         guard.stop();
         let watcher = ValuesWatcherThread::new(

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -685,12 +685,17 @@ impl ValuesWatcher {
     }
 
     /// Compares the current and stored PID. If they differ, we
-    /// are likely in a forked process and need to recreate the thread.
-    pub fn compare_pid(&self) -> ValidationResult<()> {
-        if self.pid.load(Ordering::Relaxed) != process::id() {
-            self.respawn()?;
+    /// assume we are in a forked process and stored thread
+    /// handle is dead and invalid. We then respawn the thread.
+    pub fn ensure_alive(&self) {
+        if self.pid.load(Ordering::Relaxed) != process::id()
+            && let Err(e) = self.respawn()
+        {
+            eprintln!(
+                "sentry-options: failed to respawn watcher after fork: {}",
+                e
+            );
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## summary

When a process gets forked, the child process does not spawn the parent process' child threads. This means if a process using sentry-options is forked, the child process won't get the `ValuesWatcher` thread. This is bad because the child process won't get any more values updates.

The solution is to make the `ValuesWatcher` thread aware of its PID (Process ID). On every `get()` and `isset()`, we check our PID. If it's the same, we do nothing. If it's different, we respawn the `ValuesWatcher` thread just to be safe, because we may be in a forked process.

We need to worry about this because celery uses `fork` to create a pool of child processes to execute tasks. The `ValuesWatcher` thread spawns in the parent process, and then is never passed down to the children.

## other paths considered

`pthread_atfork` would register a handler at several points in the forking lifecycle. However, it is complex to use, especially in multithreaded, multiprocess environments. Additionally, rust has no standard binding for this.

## todo
- [x] Tests for the top level `ValuesWatcher` struct with different PIDs
- [x] Investigate the added overhead of calling `ensure_alive` on every `get` and `isset`