### PR TITLE
fix(sentry): Disable sentry in forks

### DIFF
--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -51,6 +51,11 @@ const SENTRY_OPTIONS_DSN: &str = "";
 /// In test mode, creates a disabled client (empty DSN) so no spans are sent.
 static SENTRY_HUB: OnceLock<Arc<sentry::Hub>> = OnceLock::new();
 
+/// Set to true in forked child processes to prevent using the parent's
+/// Sentry transport, which has invalid internal state after fork and
+/// causes SIGSEGV when used.
+static SENTRY_DISABLED: AtomicBool = AtomicBool::new(false);
+
 fn get_sentry_hub() -> &'static Arc<sentry::Hub> {
     SENTRY_HUB.get_or_init(|| {
         let client = Arc::new(sentry::Client::from((
@@ -679,6 +684,7 @@ impl ValuesWatcher {
             return Ok(());
         }
         self.pid.store(process::id(), Ordering::Relaxed);
+        SENTRY_DISABLED.store(true, Ordering::Relaxed);
         guard.stop();
         let watcher = ValuesWatcherThread::new(
             &self.values_path,
@@ -850,6 +856,9 @@ impl ValuesWatcherThread {
         reload_duration: Duration,
         generated_at_by_namespace: &HashMap<String, String>,
     ) {
+        if SENTRY_DISABLED.load(Ordering::Relaxed) {
+            return;
+        }
         let hub = get_sentry_hub();
         let applied_at = Utc::now();
         let reload_duration_ms = reload_duration.as_secs_f64() * 1000.0;


### PR DESCRIPTION
My theory for why we are getting segfaults is sentry sdk.

This disables it