### PR TITLE
fix(watcher): Change RwLock to be ArcSwap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1534,7 @@ dependencies = [
 name = "sentry-options"
 version = "1.0.8"
 dependencies = [
+ "arc-swap",
  "num",
  "sentry-options-validation",
  "serde_json",
@@ -1562,6 +1572,7 @@ name = "sentry-options-validation"
 version = "1.0.8"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "chrono",
  "jsonschema",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ sentry = { version = "0.46", default-features = false }
 chrono = "0.4"
 openssl = { version = "0.10", features = ["vendored"] }
 sha1 = "0.10"
+arc-swap = "1.9.1"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -11,6 +11,7 @@ sentry-options-validation.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 sha1.workspace = true
+arc-swap.workspace = true
 num = "0.4.3"
 
 [dev-dependencies]

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,9 +4,10 @@ pub mod features;
 
 pub use features::{FeatureChecker, FeatureContext, features};
 
+use arc_swap::ArcSwap;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 
 use sentry_options_validation::{
     SchemaRegistry, ValidationError, ValuesWatcher, resolve_options_dir,
@@ -38,7 +39,7 @@ pub type Result<T> = std::result::Result<T, OptionsError>;
 /// Options store for reading configuration values.
 pub struct Options {
     registry: Arc<SchemaRegistry>,
-    values: Arc<RwLock<HashMap<String, HashMap<String, Value>>>>,
+    values: Arc<ArcSwap<HashMap<String, HashMap<String, Value>>>>,
     watcher: ValuesWatcher,
 }
 
@@ -67,7 +68,7 @@ impl Options {
     fn with_registry_and_values(registry: SchemaRegistry, values_dir: &Path) -> Result<Self> {
         let registry = Arc::new(registry);
         let (loaded_values, _) = registry.load_values_json(values_dir)?;
-        let values = Arc::new(RwLock::new(loaded_values));
+        let values = Arc::new(ArcSwap::from_pointee(loaded_values));
         let watcher = ValuesWatcher::new(
             values_dir.to_path_buf(),
             Arc::clone(&registry),
@@ -92,10 +93,7 @@ impl Options {
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
-        let values_guard = self
-            .values
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let values_guard = self.values.load();
         if let Some(ns_values) = values_guard.get(namespace)
             && let Some(value) = ns_values.get(key)
         {
@@ -143,11 +141,7 @@ impl Options {
             });
         }
 
-        let values_guard = self
-            .values
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
+        let values_guard = self.values.load();
         if let Some(ns_values) = values_guard.get(namespace) {
             Ok(ns_values.contains_key(key))
         } else {

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -16,6 +16,7 @@ tempfile.workspace = true
 sentry = { workspace = true, features = ["transport"] }
 chrono.workspace = true
 openssl.workspace = true
+arc-swap.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -4,6 +4,7 @@
 //! Schemas are loaded once and stored in Arc for efficient sharing.
 //! Values are validated against schemas as complete objects.
 
+use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use sentry::ClientOptions;
 use sentry::transports::DefaultTransportFactory;
@@ -15,7 +16,6 @@ use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Mutex;
-use std::sync::RwLock;
 use std::sync::atomic::AtomicU32;
 use std::sync::{
     Arc, OnceLock,
@@ -643,13 +643,13 @@ impl Default for SchemaRegistry {
 /// - If the thread panics and dies, there is no built in mechanism to catch it and restart
 /// - If a config map is unmounted, we won't reload until the next file modification (because we don't catch the deletion event)
 /// - If any namespace fails validation, we keep all old values (even the namespaces that passed validation)
-/// - If we have a steady stream of readers our writer may starve for a while trying to acquire the lock
+/// - Values are swapped atomically via ArcSwap (lock-free, fork-safe)
 /// - On drop, the thread is joined only if PID matches (skipped in forked processes)
 pub struct ValuesWatcher {
     pid: AtomicU32,
     values_path: PathBuf,
     registry: Arc<SchemaRegistry>,
-    values: Arc<RwLock<ValuesByNamespace>>,
+    values: Arc<ArcSwap<ValuesByNamespace>>,
     watcher: Mutex<ValuesWatcherThread>,
 }
 
@@ -657,7 +657,7 @@ impl ValuesWatcher {
     pub fn new(
         values_path: PathBuf,
         registry: Arc<SchemaRegistry>,
-        values: Arc<RwLock<ValuesByNamespace>>,
+        values: Arc<ArcSwap<ValuesByNamespace>>,
     ) -> ValidationResult<Self> {
         let pid = AtomicU32::new(process::id());
         let watcher = Mutex::new(ValuesWatcherThread::new(
@@ -729,7 +729,7 @@ impl ValuesWatcherThread {
     pub fn new(
         values_path: &Path,
         registry: Arc<SchemaRegistry>,
-        values: Arc<RwLock<ValuesByNamespace>>,
+        values: Arc<ArcSwap<ValuesByNamespace>>,
     ) -> ValidationResult<Self> {
         // output an error but keep passing
         if !should_suppress_missing_dir_errors() && fs::metadata(values_path).is_err() {
@@ -768,7 +768,7 @@ impl ValuesWatcherThread {
         stop_signal: Arc<AtomicBool>,
         values_path: PathBuf,
         registry: Arc<SchemaRegistry>,
-        values: Arc<RwLock<ValuesByNamespace>>,
+        values: Arc<ArcSwap<ValuesByNamespace>>,
     ) {
         let mut last_mtime = Self::get_mtime(&values_path);
 
@@ -827,7 +827,7 @@ impl ValuesWatcherThread {
     pub(crate) fn reload_values(
         values_path: &Path,
         registry: &SchemaRegistry,
-        values: &Arc<RwLock<ValuesByNamespace>>,
+        values: &Arc<ArcSwap<ValuesByNamespace>>,
     ) {
         let reload_start = Instant::now();
 
@@ -887,10 +887,8 @@ impl ValuesWatcherThread {
     }
 
     /// Update the values map with the new values
-    fn update_values(values: &Arc<RwLock<ValuesByNamespace>>, new_values: ValuesByNamespace) {
-        // safe to unwrap, we only have one thread and if it panics we die anyways
-        let mut guard = values.write().unwrap();
-        *guard = new_values;
+    fn update_values(values: &Arc<ArcSwap<ValuesByNamespace>>, new_values: ValuesByNamespace) {
+        values.store(Arc::new(new_values));
     }
 
     /// Signals the watcher thread to stop
@@ -2058,11 +2056,11 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             // ensure initial values are correct
             {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 assert_eq!(guard["ns1"]["enabled"], json!(true));
                 assert_eq!(guard["ns2"]["count"], json!(42));
             }
@@ -2084,7 +2082,7 @@ Error: \"version\" is a required property"
 
             // ensure new values are correct
             {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 assert_eq!(guard["ns1"]["enabled"], json!(false));
                 assert_eq!(guard["ns2"]["count"], json!(100));
             }
@@ -2096,10 +2094,10 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let initial_enabled = {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 guard["ns1"]["enabled"].clone()
             };
 
@@ -2114,7 +2112,7 @@ Error: \"version\" is a required property"
 
             // ensure old value persists
             {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 assert_eq!(guard["ns1"]["enabled"], initial_enabled);
             }
         }
@@ -2125,7 +2123,7 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let mut watcher =
                 ValuesWatcherThread::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
@@ -2143,7 +2141,7 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let watcher =
                 ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
@@ -2159,7 +2157,7 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let watcher =
                 ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
@@ -2183,7 +2181,7 @@ Error: \"version\" is a required property"
 
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
             let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(RwLock::new(initial_values));
+            let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let watcher = ValuesWatcher::new(
                 values_dir.clone(),
@@ -2194,7 +2192,7 @@ Error: \"version\" is a required property"
 
             // Verify initial values
             {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 assert_eq!(guard["ns1"]["enabled"], json!(true));
             }
 
@@ -2211,7 +2209,7 @@ Error: \"version\" is a required property"
 
             // Values should be reloaded from disk
             {
-                let guard = values.read().unwrap();
+                let guard = values.load();
                 assert_eq!(guard["ns1"]["enabled"], json!(false));
             }
         }


### PR DESCRIPTION
Seer was running into SIGSEGV (segfaults) in their Celery tasks in sentry-options versions 1.0.7 and 1.0.8. While we have many theories, none of them have been reproduced in Linux nor MacOS, so this is our best effort at trying to remove all possible avenues of failure.

Sometimes copying over a RwLock while forking will copy it over in a corrupted state. Instead, I switch to an `ArcSwap`. Essentially, ArcSwap is an atomic pointer (atomic u64), so reads and writes are both fast. This gets rid of one failure mode, hopefully the one that is breaking the system.

All the other mechanisms, the Arc, mutex, and underlying datastructures shouldn't cause problems. 

If this doesn't work, our real problem lies in **spawning threads after a fork**, which is discouraged by the POSIX standard. This would require us to use a thread-free solution.