### PR TITLE
fix(watcher): Revert all fork thread spawning to make latest version stable

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -40,7 +40,7 @@ pub type Result<T> = std::result::Result<T, OptionsError>;
 pub struct Options {
     registry: Arc<SchemaRegistry>,
     values: Arc<ArcSwap<HashMap<String, HashMap<String, Value>>>>,
-    watcher: ValuesWatcher,
+    _watcher: ValuesWatcher,
 }
 
 impl Options {
@@ -69,21 +69,16 @@ impl Options {
         let registry = Arc::new(registry);
         let (loaded_values, _) = registry.load_values_json(values_dir)?;
         let values = Arc::new(ArcSwap::from_pointee(loaded_values));
-        let watcher = ValuesWatcher::new(
-            values_dir.to_path_buf(),
-            Arc::clone(&registry),
-            Arc::clone(&values),
-        )?;
+        let watcher = ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values))?;
         Ok(Self {
             registry,
             values,
-            watcher,
+            _watcher: watcher,
         })
     }
 
     /// Get an option value, returning the schema default if not set.
     pub fn get(&self, namespace: &str, key: &str) -> Result<Value> {
-        self.watcher.ensure_alive();
         if let Some(value) = testing::get_override(namespace, key) {
             return Ok(value);
         }
@@ -128,7 +123,6 @@ impl Options {
     ///
     /// If the namespace or option are not defined, an Err will be returned.
     pub fn isset(&self, namespace: &str, key: &str) -> Result<bool> {
-        self.watcher.ensure_alive();
         let schema = self
             .registry
             .get(namespace)

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -808,10 +808,10 @@ impl ValuesWatcher {
         // Only join if we're in the same process that created the thread.
         // In a forked child, the thread handle is invalid (the thread
         // wasn't copied), so joining would be incorrect.
-        if self.pid == process::id() {
-            if let Some(handle) = self.thread.take() {
-                let _ = handle.join();
-            }
+        if self.pid == process::id()
+            && let Some(handle) = self.thread.take()
+        {
+            let _ = handle.join();
         }
     }
 

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -715,12 +715,7 @@ impl ValuesWatcher {
 
         let entries = match fs::read_dir(values_dir) {
             Ok(e) => e,
-            Err(e) => {
-                if !should_suppress_missing_dir_errors() {
-                    eprintln!("Failed to read directory {}: {}", values_dir.display(), e);
-                }
-                return None;
-            }
+            Err(_) => return None,
         };
 
         for entry in entries.flatten() {

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -49,11 +49,6 @@ const SENTRY_OPTIONS_DSN: &str = "";
 /// In test mode, creates a disabled client (empty DSN) so no spans are sent.
 static SENTRY_HUB: OnceLock<Arc<sentry::Hub>> = OnceLock::new();
 
-/// Set to true in forked child processes to prevent using the parent's
-/// Sentry transport, which has invalid internal state after fork and
-/// causes SIGSEGV when used.
-static SENTRY_DISABLED: AtomicBool = AtomicBool::new(false);
-
 fn get_sentry_hub() -> &'static Arc<sentry::Hub> {
     SENTRY_HUB.get_or_init(|| {
         let client = Arc::new(sentry::Client::from((
@@ -774,9 +769,6 @@ impl ValuesWatcher {
         reload_duration: Duration,
         generated_at_by_namespace: &HashMap<String, String>,
     ) {
-        if SENTRY_DISABLED.load(Ordering::Relaxed) {
-            return;
-        }
         let hub = get_sentry_hub();
         let applied_at = Utc::now();
         let reload_duration_ms = reload_duration.as_secs_f64() * 1000.0;

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -15,8 +15,6 @@ use std::fs;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process;
-use std::sync::Mutex;
-use std::sync::atomic::AtomicU32;
 use std::sync::{
     Arc, OnceLock,
     atomic::{AtomicBool, Ordering},
@@ -633,11 +631,9 @@ impl Default for SchemaRegistry {
 ///
 /// Does not do an initial fetch, assumes the caller has already loaded values.
 /// Child thread may panic if we run out of memory or cannot create more threads.
+/// We do NOT respawn the values watcher thread for forked processes.
 ///
 /// Uses polling for now, could use `inotify` or similar later on.
-///
-/// This thread will not be copied when a parent process is forked, so we track the initial PID
-/// and recreate the thread handle if it doesn't match the current process PID.
 ///
 /// Some important notes:
 /// - If the thread panics and dies, there is no built in mechanism to catch it and restart
@@ -646,86 +642,13 @@ impl Default for SchemaRegistry {
 /// - Values are swapped atomically via ArcSwap (lock-free, fork-safe)
 /// - On drop, the thread is joined only if PID matches (skipped in forked processes)
 pub struct ValuesWatcher {
-    pid: AtomicU32,
-    values_path: PathBuf,
-    registry: Arc<SchemaRegistry>,
-    values: Arc<ArcSwap<ValuesByNamespace>>,
-    watcher: Mutex<ValuesWatcherThread>,
-}
-
-impl ValuesWatcher {
-    pub fn new(
-        values_path: PathBuf,
-        registry: Arc<SchemaRegistry>,
-        values: Arc<ArcSwap<ValuesByNamespace>>,
-    ) -> ValidationResult<Self> {
-        let pid = AtomicU32::new(process::id());
-        let watcher = Mutex::new(ValuesWatcherThread::new(
-            &values_path,
-            Arc::clone(&registry),
-            Arc::clone(&values),
-        )?);
-        Ok(Self {
-            pid,
-            values_path,
-            registry,
-            values,
-            watcher,
-        })
-    }
-
-    /// Re-creates the value watcher thread with the same arguments in a
-    /// thread-safe manner. Handles updating the PID and stopping the old thread.
-    /// Force reloads values so the child process has fresh data.
-    fn respawn(&self) -> ValidationResult<()> {
-        let mut guard = self.watcher.lock().unwrap_or_else(|e| e.into_inner());
-        // just in case another thread has called this already
-        if self.pid.load(Ordering::Relaxed) == process::id() {
-            return Ok(());
-        }
-        self.pid.store(process::id(), Ordering::Relaxed);
-        SENTRY_DISABLED.store(true, Ordering::Relaxed);
-        guard.stop();
-        let watcher = ValuesWatcherThread::new(
-            &self.values_path,
-            Arc::clone(&self.registry),
-            Arc::clone(&self.values),
-        )?;
-        *guard = watcher;
-
-        // Force reload values so the new watcher thread's mtime baseline
-        // is consistent with what's in memory. Without this, the child
-        // process could have stale values if the file changed since the fork.
-        ValuesWatcherThread::reload_values(&self.values_path, &self.registry, &self.values);
-
-        Ok(())
-    }
-
-    /// Compares the current and stored PID. If they differ, we
-    /// assume we are in a forked process and stored thread
-    /// handle is dead and invalid. We then respawn the thread.
-    pub fn ensure_alive(&self) {
-        if self.pid.load(Ordering::Relaxed) != process::id()
-            && let Err(e) = self.respawn()
-        {
-            eprintln!(
-                "sentry-options: failed to respawn watcher after fork: {}",
-                e
-            );
-        }
-    }
-}
-
-/// The actual value watcher thread struct, containing the
-/// thread handle and cancellation signal.
-pub struct ValuesWatcherThread {
     pid: u32,
     stop_signal: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
 }
 
-impl ValuesWatcherThread {
-    /// Creates a new ValuesWatcherThread and spins up the watcher thread
+impl ValuesWatcher {
+    /// Creates a new ValuesWatcher and spins up the watcher thread
     pub fn new(
         values_path: &Path,
         registry: Arc<SchemaRegistry>,
@@ -891,15 +814,17 @@ impl ValuesWatcherThread {
         values.store(Arc::new(new_values));
     }
 
-    /// Signals the watcher thread to stop
+    /// Stops the watcher thread, waiting for it to join.
+    /// May take up to POLLING_DELAY seconds
     pub fn stop(&mut self) {
         self.stop_signal.store(true, Ordering::Relaxed);
-    }
-
-    /// Joins the watcher thread, blocking until it finishes
-    fn join(&mut self) {
-        if let Some(handle) = self.thread.take() {
-            let _ = handle.join();
+        // Only join if we're in the same process that created the thread.
+        // In a forked child, the thread handle is invalid (the thread
+        // wasn't copied), so joining would be incorrect.
+        if self.pid == process::id() {
+            if let Some(handle) = self.thread.take() {
+                let _ = handle.join();
+            }
         }
     }
 
@@ -909,15 +834,9 @@ impl ValuesWatcherThread {
     }
 }
 
-impl Drop for ValuesWatcherThread {
+impl Drop for ValuesWatcher {
     fn drop(&mut self) {
         self.stop();
-        // Only join if we're in the same process that created the thread.
-        // In a forked child, the thread handle is invalid (the thread
-        // wasn't copied), so joining would be incorrect.
-        if self.pid == process::id() {
-            self.join();
-        }
     }
 }
 
@@ -2024,7 +1943,7 @@ Error: \"version\" is a required property"
             let (_temp, _schemas, values_dir) = setup_watcher_test();
 
             // Get initial mtime
-            let mtime1 = ValuesWatcherThread::get_mtime(&values_dir);
+            let mtime1 = ValuesWatcher::get_mtime(&values_dir);
             assert!(mtime1.is_some());
 
             // Modify one namespace
@@ -2036,7 +1955,7 @@ Error: \"version\" is a required property"
             .unwrap();
 
             // Should detect the change
-            let mtime2 = ValuesWatcherThread::get_mtime(&values_dir);
+            let mtime2 = ValuesWatcher::get_mtime(&values_dir);
             assert!(mtime2.is_some());
             assert!(mtime2 > mtime1);
         }
@@ -2046,7 +1965,7 @@ Error: \"version\" is a required property"
             let temp = TempDir::new().unwrap();
             let nonexistent = temp.path().join("nonexistent");
 
-            let mtime = ValuesWatcherThread::get_mtime(&nonexistent);
+            let mtime = ValuesWatcher::get_mtime(&nonexistent);
             assert!(mtime.is_none());
         }
 
@@ -2078,7 +1997,7 @@ Error: \"version\" is a required property"
             .unwrap();
 
             // force a reload
-            ValuesWatcherThread::reload_values(&values_dir, &registry, &values);
+            ValuesWatcher::reload_values(&values_dir, &registry, &values);
 
             // ensure new values are correct
             {
@@ -2108,7 +2027,7 @@ Error: \"version\" is a required property"
             )
             .unwrap();
 
-            ValuesWatcherThread::reload_values(&values_dir, &registry, &values);
+            ValuesWatcher::reload_values(&values_dir, &registry, &values);
 
             // ensure old value persists
             {
@@ -2126,92 +2045,12 @@ Error: \"version\" is a required property"
             let values = Arc::new(ArcSwap::from_pointee(initial_values));
 
             let mut watcher =
-                ValuesWatcherThread::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
+                ValuesWatcher::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
                     .expect("Failed to create watcher");
 
             assert!(watcher.is_alive());
             watcher.stop();
-            watcher.join();
             assert!(!watcher.is_alive());
-        }
-
-        #[test]
-        fn test_ensure_alive_noop_when_pid_matches() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
-
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
-
-            let watcher =
-                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
-
-            // PID matches, ensure_alive should be a no-op
-            watcher.ensure_alive();
-            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
-        }
-
-        #[test]
-        fn test_ensure_alive_respawns_on_pid_mismatch() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
-
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
-
-            let watcher =
-                ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values)).unwrap();
-
-            // Simulate a fork by setting the stored PID to something different
-            watcher.pid.store(0, Ordering::Relaxed);
-
-            watcher.ensure_alive();
-
-            // After respawn, stored PID should match current process
-            assert_eq!(watcher.pid.load(Ordering::Relaxed), process::id());
-
-            // The new watcher thread should be alive
-            let guard = watcher.watcher.lock().unwrap();
-            assert!(guard.is_alive());
-        }
-
-        #[test]
-        fn test_respawn_reloads_values_from_disk() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
-
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
-
-            let watcher = ValuesWatcher::new(
-                values_dir.clone(),
-                Arc::clone(&registry),
-                Arc::clone(&values),
-            )
-            .unwrap();
-
-            // Verify initial values
-            {
-                let guard = values.load();
-                assert_eq!(guard["ns1"]["enabled"], json!(true));
-            }
-
-            // Change values on disk
-            fs::write(
-                values_dir.join("ns1").join("values.json"),
-                r#"{"options": {"enabled": false}}"#,
-            )
-            .unwrap();
-
-            // Simulate a fork and trigger respawn
-            watcher.pid.store(0, Ordering::Relaxed);
-            watcher.ensure_alive();
-
-            // Values should be reloaded from disk
-            {
-                let guard = values.load();
-                assert_eq!(guard["ns1"]["enabled"], json!(false));
-            }
         }
     }
     mod array_tests {


### PR DESCRIPTION
1.0.7 introduced thread spawning in forked processes, causing segfaults in seer's application.

Our latest version should not have these changes latent just because nobody is using the latest, so this PR reverts all those spawning changes.

We still keep the changes in 1.0.8 and 1.0.9, namely:
- Sentry is disabled in forked processes
- We use ArcSwap instead of RWLock