### PR TITLE
feat(sentry-options):  Refresh values lazily on read; drop the watcher thread and embedded Sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,12 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,9 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -259,16 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,35 +273,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -422,21 +375,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -549,12 +487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,12 +527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,22 +545,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -938,23 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,12 +885,6 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1052,60 +939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,15 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,12 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,21 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -1281,35 +1084,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1399,20 +1173,16 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1433,15 +1203,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -1466,69 +1227,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "sentry"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
-dependencies = [
- "httpdate",
- "native-tls",
- "reqwest",
- "sentry-core",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab054c34b87f96c3e4701bea1888317cde30cc7e4a6136d2c48454ab96661c"
-dependencies = [
- "rand",
- "sentry-types",
- "serde",
- "serde_json",
- "url",
-]
 
 [[package]]
 name = "sentry-options"
@@ -1573,31 +1275,11 @@ version = "1.0.10"
 dependencies = [
  "anyhow",
  "arc-swap",
- "chrono",
  "jsonschema",
- "openssl",
- "sentry",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecbd63e9d15a26a40675ed180d376fcb434635d2e33de1c24003f61e3e2230d"
-dependencies = [
- "debugid",
- "hex",
- "rand",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -1790,37 +1472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,22 +1487,11 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -1955,35 +1595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "ureq"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
-dependencies = [
- "base64",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "ureq-proto",
- "utf-8",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,12 +1605,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2014,17 +1619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
-dependencies = [
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "uuid-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,12 +1627,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2152,15 +1740,6 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2389,12 +1968,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,5 @@ anyhow = "1.0.100"
 thiserror = "2.0.17"
 tempfile = "3.23.0"
 jsonschema = "0.36.0"
-sentry = { version = "0.46", default-features = false }
-chrono = "0.4"
-openssl = { version = "0.10", features = ["vendored"] }
 sha1 = "0.10"
 arc-swap = "1.9.1"

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,13 +4,11 @@ pub mod features;
 
 pub use features::{FeatureChecker, FeatureContext, features};
 
-use arc_swap::ArcSwap;
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
 use sentry_options_validation::{
-    SchemaRegistry, ValidationError, ValuesWatcher, resolve_options_dir,
+    SchemaRegistry, ValidationError, ValuesStore, resolve_options_dir,
 };
 use serde_json::Value;
 use thiserror::Error;
@@ -38,9 +36,7 @@ pub type Result<T> = std::result::Result<T, OptionsError>;
 
 /// Options store for reading configuration values.
 pub struct Options {
-    registry: Arc<SchemaRegistry>,
-    values: Arc<ArcSwap<HashMap<String, HashMap<String, Value>>>>,
-    _watcher: ValuesWatcher,
+    store: ValuesStore,
 }
 
 impl Options {
@@ -66,15 +62,8 @@ impl Options {
     }
 
     fn with_registry_and_values(registry: SchemaRegistry, values_dir: &Path) -> Result<Self> {
-        let registry = Arc::new(registry);
-        let (loaded_values, _) = registry.load_values_json(values_dir)?;
-        let values = Arc::new(ArcSwap::from_pointee(loaded_values));
-        let watcher = ValuesWatcher::new(values_dir, Arc::clone(&registry), Arc::clone(&values))?;
-        Ok(Self {
-            registry,
-            values,
-            _watcher: watcher,
-        })
+        let store = ValuesStore::new(Arc::new(registry), values_dir)?;
+        Ok(Self { store })
     }
 
     /// Get an option value, returning the schema default if not set.
@@ -84,11 +73,12 @@ impl Options {
         }
 
         let schema = self
-            .registry
+            .store
+            .registry()
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
-        let values_guard = self.values.load();
+        let values_guard = self.store.load();
         if let Some(ns_values) = values_guard.get(namespace)
             && let Some(value) = ns_values.get(key)
         {
@@ -108,7 +98,8 @@ impl Options {
     /// Validate that a key exists in the schema and the value matches the expected type.
     pub fn validate_override(&self, namespace: &str, key: &str, value: &Value) -> Result<()> {
         let schema = self
-            .registry
+            .store
+            .registry()
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
@@ -116,6 +107,7 @@ impl Options {
 
         Ok(())
     }
+
     /// Check if an option has a value.
     ///
     /// Returns true if the option is defined and has a value, will return
@@ -124,7 +116,8 @@ impl Options {
     /// If the namespace or option are not defined, an Err will be returned.
     pub fn isset(&self, namespace: &str, key: &str) -> Result<bool> {
         let schema = self
-            .registry
+            .store
+            .registry()
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
@@ -135,7 +128,7 @@ impl Options {
             });
         }
 
-        let values_guard = self.values.load();
+        let values_guard = self.store.load();
         if let Some(ns_values) = values_guard.get(namespace) {
             Ok(ns_values.contains_key(key))
         } else {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,9 +480,9 @@ Reject unknown options, fail fast on type mismatches.
 
 | Environment | Path |
 |-------------|------|
-| Production | `/etc/sentry-options/{namespace}/values.json` |
+| Production | `/etc/sentry-options/values/{namespace}/values.json` |
 | Override | `SENTRY_OPTIONS_DIR` environment variable |
-| Local dev | `./sentry-options/{namespace}/values.json` |
+| Local dev | `./sentry-options/values/{namespace}/values.json` |
 
 ## Open Questions
 

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -13,9 +13,6 @@ anyhow.workspace = true
 thiserror.workspace = true
 jsonschema.workspace = true
 tempfile.workspace = true
-sentry = { workspace = true, features = ["transport"] }
-chrono.workspace = true
-openssl.workspace = true
 arc-swap.workspace = true
 
 [dev-dependencies]

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -1,8 +1,41 @@
-//! Schema validation library for sentry-options
+//! Schema validation library for sentry-options.
 //!
-//! This library provides schema loading and validation for sentry-options.
-//! Schemas are loaded once and stored in Arc for efficient sharing.
+//! Schemas are loaded once into a [`SchemaRegistry`] and shared via `Arc`.
 //! Values are validated against schemas as complete objects.
+//!
+//! # Refresh-on-read scheme
+//!
+//! Values are held in a [`ValuesStore`] that wraps an [`ArcSwap`] for
+//! lock-free reads. There is no background thread — every `load()` decides
+//! whether the cached snapshot is stale and, if so, the calling thread
+//! refreshes it.
+//!
+//! Each `load()` does:
+//!
+//! 1. Read `now` and `last_updated` (an `AtomicU64` of nanoseconds since a
+//!    monotonic baseline) with `Acquire`.
+//! 2. Compute a per-call jitter in `[0, 1s)` from the address of a stack
+//!    local — different threads have different stack bases, so the value
+//!    differs across threads. No `thread_local` is involved.
+//! 3. If `now - last_updated < threshold + jitter`, return the current
+//!    snapshot. Otherwise:
+//!    a. Read all values files from disk and build the new map.
+//!    b. On success, publish the new map into the `ArcSwap`
+//!       (last-writer-wins under contention).
+//!    c. `compare_exchange` `last_updated` from the previously-observed
+//!       value to `now` with `AcqRel`. The Release on the timestamp
+//!       publishes the prior `ArcSwap::store`: any reader that
+//!       Acquire-loads the bumped timestamp and short-circuits the
+//!       refresh is guaranteed to subsequently load the new snapshot.
+//!    d. On a parse/validation failure, leave the old map in place — the
+//!       bumped timestamp makes other threads back off until the next
+//!       window.
+//!
+//! Multiple threads racing through the stale window will redundantly read
+//! files and publish; the last `ArcSwap::store` wins. The jitter spreads
+//! the threshold boundary so that the herd doesn't cross it together. On
+//! error the timestamp is still bumped so a broken values directory does
+//! not turn into an I/O storm.
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
@@ -12,14 +45,11 @@ use serde_json::Value;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
-use std::process;
 use std::sync::{
     Arc, OnceLock,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicU64, Ordering},
 };
-use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 /// Embedded meta-schema for validating sentry-options schema files
@@ -31,8 +61,10 @@ const FEATURE_SCHEMA_DEFS_JSON: &str = include_str!("feature-schema-defs.json");
 const SCHEMA_FILE_NAME: &str = "schema.json";
 const VALUES_FILE_NAME: &str = "values.json";
 
-/// Time between file polls in seconds
-const POLLING_DELAY: u64 = 5;
+/// Default minimum age of a cached values snapshot before a read triggers a
+/// refresh. A per-thread jitter of up to 1 s is added on top to spread the
+/// reload across threads.
+const REFRESH_THRESHOLD: Duration = Duration::from_secs(5);
 
 /// Dedicated Sentry DSN for sentry-options observability.
 /// This is separate from the host application's Sentry setup.
@@ -621,209 +653,173 @@ impl Default for SchemaRegistry {
     }
 }
 
-/// Watches the values directory for changes, reloading if there are any.
-/// If the directory does not exist we do not panic
+/// Lazily reloads values from disk when reads detect they are stale.
 ///
-/// Does not do an initial fetch, assumes the caller has already loaded values.
-/// Child thread may panic if we run out of memory or cannot create more threads.
-/// We do NOT respawn the values watcher thread for forked processes.
+/// Holds the current `ValuesByNamespace` snapshot in an `ArcSwap` for
+/// lock-free reads. Every `load()` checks whether the snapshot is older than
+/// `refresh_threshold + jitter`; if so, the calling thread reads the values
+/// directory, then compare-and-swaps the timestamp. Whichever thread wins the
+/// CAS publishes its snapshot into the `ArcSwap`; losers discard their work.
 ///
-/// Uses polling for now, could use `inotify` or similar later on.
-///
-/// Some important notes:
-/// - If the thread panics and dies, there is no built in mechanism to catch it and restart
-/// - If a config map is unmounted, we won't reload until the next file modification (because we don't catch the deletion event)
-/// - If any namespace fails validation, we keep all old values (even the namespaces that passed validation)
-/// - Values are swapped atomically via ArcSwap (lock-free, fork-safe)
-/// - On drop, the thread is joined only if PID matches (skipped in forked processes)
-pub struct ValuesWatcher {
-    pid: u32,
-    stop_signal: Arc<AtomicBool>,
-    thread: Option<JoinHandle<()>>,
+/// Replaces the polling watcher thread: idle processes do no work, and
+/// concurrent readers coordinate through the timestamp CAS.
+pub struct ValuesStore {
+    registry: Arc<SchemaRegistry>,
+    values_dir: PathBuf,
+    values: ArcSwap<ValuesByNamespace>,
+    baseline: Instant,
+    last_refresh_offset_ns: AtomicU64,
+    refresh_threshold: Duration,
 }
 
-impl ValuesWatcher {
-    /// Creates a new ValuesWatcher and spins up the watcher thread
-    pub fn new(
-        values_path: &Path,
+impl ValuesStore {
+    /// Build a store and perform the initial values load synchronously.
+    pub fn new(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValidationResult<Self> {
+        Self::with_threshold(registry, values_dir, REFRESH_THRESHOLD)
+    }
+
+    /// Test-only constructor that lets the caller pick the refresh threshold.
+    /// `Duration::ZERO` makes every `load()` perform a refresh attempt.
+    pub(crate) fn with_threshold(
         registry: Arc<SchemaRegistry>,
-        values: Arc<ArcSwap<ValuesByNamespace>>,
+        values_dir: &Path,
+        refresh_threshold: Duration,
     ) -> ValidationResult<Self> {
-        // output an error but keep passing
-        if !should_suppress_missing_dir_errors() && fs::metadata(values_path).is_err() {
-            eprintln!("Values directory does not exist: {}", values_path.display());
+        if !should_suppress_missing_dir_errors() && fs::metadata(values_dir).is_err() {
+            eprintln!("Values directory does not exist: {}", values_dir.display());
         }
 
-        let stop_signal = Arc::new(AtomicBool::new(false));
-
-        let thread_signal = Arc::clone(&stop_signal);
-        let thread_path = values_path.to_path_buf();
-        let thread_registry = Arc::clone(&registry);
-        let thread_values = Arc::clone(&values);
-        let thread = thread::Builder::new()
-            .name("sentry-options-watcher".into())
-            .spawn(move || {
-                let result = panic::catch_unwind(AssertUnwindSafe(|| {
-                    Self::run(thread_signal, thread_path, thread_registry, thread_values);
-                }));
-                if let Err(e) = result {
-                    eprintln!("Watcher thread panicked with: {:?}", e);
-                }
-            })?;
+        let baseline = Instant::now();
+        let (initial, _) = registry.load_values_json(values_dir)?;
+        let last_refresh_offset_ns = AtomicU64::new(baseline.elapsed().as_nanos() as u64);
 
         Ok(Self {
-            pid: process::id(),
-            stop_signal,
-            thread: Some(thread),
+            registry,
+            values_dir: values_dir.to_path_buf(),
+            values: ArcSwap::from_pointee(initial),
+            baseline,
+            last_refresh_offset_ns,
+            refresh_threshold,
         })
     }
 
-    /// Reloads the values if the modified time has changed.
-    ///
-    /// Continuously polls the values directory and reloads all values
-    /// if any modification is detected.
-    fn run(
-        stop_signal: Arc<AtomicBool>,
-        values_path: PathBuf,
-        registry: Arc<SchemaRegistry>,
-        values: Arc<ArcSwap<ValuesByNamespace>>,
-    ) {
-        let mut last_mtime = Self::get_mtime(&values_path);
-
-        while !stop_signal.load(Ordering::Relaxed) {
-            // does not reload values if get_mtime fails
-            if let Some(current_mtime) = Self::get_mtime(&values_path)
-                && Some(current_mtime) != last_mtime
-            {
-                Self::reload_values(&values_path, &registry, &values);
-                last_mtime = Some(current_mtime);
-            }
-
-            thread::sleep(Duration::from_secs(POLLING_DELAY));
-        }
+    /// The registry the store was constructed with.
+    pub fn registry(&self) -> &Arc<SchemaRegistry> {
+        &self.registry
     }
 
-    /// Get the most recent modification time across all namespace values.json files
-    /// Returns None if no valid values files are found
-    fn get_mtime(values_dir: &Path) -> Option<std::time::SystemTime> {
-        let mut latest_mtime = None;
+    /// Returns a guard onto the current values snapshot, refreshing first if
+    /// the cached snapshot is older than `refresh_threshold + jitter`.
+    pub fn load(&self) -> arc_swap::Guard<Arc<ValuesByNamespace>> {
+        self.maybe_refresh();
+        self.values.load()
+    }
 
-        let entries = match fs::read_dir(values_dir) {
-            Ok(e) => e,
-            Err(_) => return None,
+    fn maybe_refresh(&self) {
+        let now_ns = self.baseline.elapsed().as_nanos() as u64;
+        let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);
+        let elapsed_ns = now_ns.saturating_sub(last_ns);
+        let threshold_ns = self.refresh_threshold.as_nanos() as u64;
+        // Skip jitter for a zero threshold so callers (chiefly tests) can
+        // force every read to refresh.
+        let jitter_ns = if self.refresh_threshold.is_zero() {
+            0
+        } else {
+            stack_jitter_ns()
         };
 
-        for entry in entries.flatten() {
-            // skip if not a dir
-            if !entry
-                .file_type()
-                .map(|file_type| file_type.is_dir())
-                .unwrap_or(false)
-            {
-                continue;
-            }
-
-            let values_file = entry.path().join(VALUES_FILE_NAME);
-            if let Ok(metadata) = fs::metadata(&values_file)
-                && let Ok(mtime) = metadata.modified()
-                && latest_mtime.is_none_or(|latest| mtime > latest)
-            {
-                latest_mtime = Some(mtime);
-            }
+        if elapsed_ns < threshold_ns.saturating_add(jitter_ns) {
+            return;
         }
 
-        latest_mtime
+        self.refresh(last_ns, now_ns);
     }
 
-    /// Reload values from disk, validate them, and update the shared map.
-    /// Emits a Sentry transaction per namespace with timing and propagation delay metrics.
-    pub(crate) fn reload_values(
-        values_path: &Path,
-        registry: &SchemaRegistry,
-        values: &Arc<ArcSwap<ValuesByNamespace>>,
-    ) {
+    fn refresh(&self, observed_last_ns: u64, now_ns: u64) {
         let reload_start = Instant::now();
+        let result = self.registry.load_values_json(&self.values_dir);
 
-        match registry.load_values_json(values_path) {
+        // Publish the new snapshot before bumping the timestamp. The CAS below
+        // uses AcqRel (Release on success); a reader that Acquire-loads the
+        // bumped timestamp and decides the snapshot is fresh enough to skip
+        // refreshing is then guaranteed to observe this `ArcSwap::store`.
+        // Reversing the order opens a window where the timestamp says "fresh"
+        // but the ArcSwap still holds the previous snapshot on weakly ordered
+        // architectures.
+        match result {
             Ok((new_values, generated_at_by_namespace)) => {
                 let namespaces: Vec<String> = new_values.keys().cloned().collect();
-                Self::update_values(values, new_values);
-
-                let reload_duration = reload_start.elapsed();
-                Self::emit_reload_spans(&namespaces, reload_duration, &generated_at_by_namespace);
+                self.values.store(Arc::new(new_values));
+                emit_reload_spans(
+                    &namespaces,
+                    reload_start.elapsed(),
+                    &generated_at_by_namespace,
+                );
             }
             Err(e) => {
                 eprintln!(
                     "Failed to reload values from {}: {}",
-                    values_path.display(),
+                    self.values_dir.display(),
                     e
                 );
             }
         }
-    }
 
-    /// Emit a Sentry transaction per namespace with reload timing and propagation delay metrics.
-    /// Uses a dedicated Sentry Hub isolated from the host application's Sentry setup.
-    fn emit_reload_spans(
-        namespaces: &[String],
-        reload_duration: Duration,
-        generated_at_by_namespace: &HashMap<String, String>,
-    ) {
-        let hub = get_sentry_hub();
-        let applied_at = Utc::now();
-        let reload_duration_ms = reload_duration.as_secs_f64() * 1000.0;
-
-        for namespace in namespaces {
-            let mut tx_ctx = sentry::TransactionContext::new(namespace, "sentry_options.reload");
-            tx_ctx.set_sampled(true);
-
-            let transaction = hub.start_transaction(tx_ctx);
-            transaction.set_data("reload_duration_ms", reload_duration_ms.into());
-            transaction.set_data("applied_at", applied_at.to_rfc3339().into());
-
-            if let Some(ts) = generated_at_by_namespace.get(namespace) {
-                transaction.set_data("generated_at", ts.as_str().into());
-
-                if let Ok(generated_time) = DateTime::parse_from_rfc3339(ts) {
-                    let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
-                        .num_milliseconds() as f64
-                        / 1000.0;
-                    transaction.set_data("propagation_delay_secs", delay_secs.into());
-                }
-            }
-
-            transaction.finish();
-        }
-    }
-
-    /// Update the values map with the new values
-    fn update_values(values: &Arc<ArcSwap<ValuesByNamespace>>, new_values: ValuesByNamespace) {
-        values.store(Arc::new(new_values));
-    }
-
-    /// Stops the watcher thread, waiting for it to join.
-    /// May take up to POLLING_DELAY seconds
-    pub fn stop(&mut self) {
-        self.stop_signal.store(true, Ordering::Relaxed);
-        // Only join if we're in the same process that created the thread.
-        // In a forked child, the thread handle is invalid (the thread
-        // wasn't copied), so joining would be incorrect.
-        if self.pid == process::id()
-            && let Some(handle) = self.thread.take()
-        {
-            let _ = handle.join();
-        }
-    }
-
-    /// Returns whether the watcher thread is still running
-    pub fn is_alive(&self) -> bool {
-        self.thread.as_ref().is_some_and(|t| !t.is_finished())
+        // Bump the timestamp regardless of success. On failure, the bumped
+        // timestamp keeps subsequent reads from hammering the filesystem until
+        // the next threshold window. Losing the CAS just means another thread
+        // already bumped — our snapshot, if any, is still published.
+        let _ = self.last_refresh_offset_ns.compare_exchange(
+            observed_last_ns,
+            now_ns,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        );
     }
 }
 
-impl Drop for ValuesWatcher {
-    fn drop(&mut self) {
-        self.stop();
+/// Per-call jitter in `[0, 1s)` nanoseconds, derived from the address of a
+/// stack local. Different threads have different stack bases, so the value
+/// differs across threads; the same thread + call site stays roughly stable.
+/// Cheap (~5 ns) and avoids `thread_local`.
+fn stack_jitter_ns() -> u64 {
+    let local = 0u8;
+    let addr = &local as *const u8 as usize as u64;
+    addr.wrapping_mul(0x9E37_79B9_7F4A_7C15) % 1_000_000_000
+}
+
+/// Emit a Sentry transaction per namespace with reload timing and propagation
+/// delay metrics. Uses the dedicated sentry-options hub isolated from the
+/// host application's Sentry setup.
+fn emit_reload_spans(
+    namespaces: &[String],
+    reload_duration: Duration,
+    generated_at_by_namespace: &HashMap<String, String>,
+) {
+    let hub = get_sentry_hub();
+    let applied_at = Utc::now();
+    let reload_duration_ms = reload_duration.as_secs_f64() * 1000.0;
+
+    for namespace in namespaces {
+        let mut tx_ctx = sentry::TransactionContext::new(namespace, "sentry_options.reload");
+        tx_ctx.set_sampled(true);
+
+        let transaction = hub.start_transaction(tx_ctx);
+        transaction.set_data("reload_duration_ms", reload_duration_ms.into());
+        transaction.set_data("applied_at", applied_at.to_rfc3339().into());
+
+        if let Some(ts) = generated_at_by_namespace.get(namespace) {
+            transaction.set_data("generated_at", ts.as_str().into());
+
+            if let Ok(generated_time) = DateTime::parse_from_rfc3339(ts) {
+                let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
+                    .num_milliseconds() as f64
+                    / 1000.0;
+                transaction.set_data("propagation_delay_secs", delay_secs.into());
+            }
+        }
+
+        transaction.finish();
     }
 }
 
@@ -1868,12 +1864,11 @@ Error: \"version\" is a required property"
         }
     }
 
-    mod watcher_tests {
+    mod store_tests {
         use super::*;
-        use std::thread;
 
-        /// Creates schema and values files for two namespaces: ns1, and ns2
-        fn setup_watcher_test() -> (TempDir, PathBuf, PathBuf) {
+        /// Creates schema and values files for two namespaces: ns1 and ns2.
+        fn setup_store_test() -> (TempDir, PathBuf, PathBuf) {
             let temp_dir = TempDir::new().unwrap();
             let schemas_dir = temp_dir.path().join("schemas");
             let values_dir = temp_dir.path().join("values");
@@ -1925,53 +1920,52 @@ Error: \"version\" is a required property"
             (temp_dir, schemas_dir, values_dir)
         }
 
+        fn store_with_zero_threshold(schemas_dir: &Path, values_dir: &Path) -> ValuesStore {
+            let registry = Arc::new(SchemaRegistry::from_directory(schemas_dir).unwrap());
+            ValuesStore::with_threshold(registry, values_dir, Duration::ZERO).unwrap()
+        }
+
         #[test]
-        fn test_get_mtime_returns_most_recent() {
-            let (_temp, _schemas, values_dir) = setup_watcher_test();
+        fn test_initial_load_populates_values() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let store = ValuesStore::new(registry, &values_dir).unwrap();
 
-            // Get initial mtime
-            let mtime1 = ValuesWatcher::get_mtime(&values_dir);
-            assert!(mtime1.is_some());
+            let guard = store.load();
+            assert_eq!(guard["ns1"]["enabled"], json!(true));
+            assert_eq!(guard["ns2"]["count"], json!(42));
+        }
 
-            // Modify one namespace
-            thread::sleep(std::time::Duration::from_millis(10));
+        #[test]
+        fn test_read_within_threshold_serves_cached() {
+            // Default 5 s threshold: a modification followed by an immediate
+            // read should still see the cached value.
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let store = ValuesStore::new(registry, &values_dir).unwrap();
+
+            // Confirm initial value, then modify the file.
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
             fs::write(
                 values_dir.join("ns1").join("values.json"),
                 r#"{"options": {"enabled": false}}"#,
             )
             .unwrap();
 
-            // Should detect the change
-            let mtime2 = ValuesWatcher::get_mtime(&values_dir);
-            assert!(mtime2.is_some());
-            assert!(mtime2 > mtime1);
+            // Within the threshold window, the cached value is still served.
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
         }
 
         #[test]
-        fn test_get_mtime_with_missing_directory() {
-            let temp = TempDir::new().unwrap();
-            let nonexistent = temp.path().join("nonexistent");
+        fn test_read_after_threshold_refreshes() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = store_with_zero_threshold(&schemas_dir, &values_dir);
 
-            let mtime = ValuesWatcher::get_mtime(&nonexistent);
-            assert!(mtime.is_none());
-        }
+            // Initial values.
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
+            assert_eq!(store.load()["ns2"]["count"], json!(42));
 
-        #[test]
-        fn test_reload_values_updates_map() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
-
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
-
-            // ensure initial values are correct
-            {
-                let guard = values.load();
-                assert_eq!(guard["ns1"]["enabled"], json!(true));
-                assert_eq!(guard["ns2"]["count"], json!(42));
-            }
-
-            // modify
+            // Modify both namespaces.
             fs::write(
                 values_dir.join("ns1").join("values.json"),
                 r#"{"options": {"enabled": false}}"#,
@@ -1983,61 +1977,57 @@ Error: \"version\" is a required property"
             )
             .unwrap();
 
-            // force a reload
-            ValuesWatcher::reload_values(&values_dir, &registry, &values);
-
-            // ensure new values are correct
-            {
-                let guard = values.load();
-                assert_eq!(guard["ns1"]["enabled"], json!(false));
-                assert_eq!(guard["ns2"]["count"], json!(100));
-            }
+            // With a zero threshold, the next read refreshes.
+            let guard = store.load();
+            assert_eq!(guard["ns1"]["enabled"], json!(false));
+            assert_eq!(guard["ns2"]["count"], json!(100));
         }
 
         #[test]
-        fn test_old_values_persist_with_invalid_data() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+        fn test_refresh_failure_keeps_old_values() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = store_with_zero_threshold(&schemas_dir, &values_dir);
 
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
 
-            let initial_enabled = {
-                let guard = values.load();
-                guard["ns1"]["enabled"].clone()
-            };
-
-            // won't pass validation
+            // Replace ns1 values with a type-incompatible payload.
             fs::write(
                 values_dir.join("ns1").join("values.json"),
                 r#"{"options": {"enabled": "not-a-boolean"}}"#,
             )
             .unwrap();
 
-            ValuesWatcher::reload_values(&values_dir, &registry, &values);
-
-            // ensure old value persists
-            {
-                let guard = values.load();
-                assert_eq!(guard["ns1"]["enabled"], initial_enabled);
-            }
+            // Refresh attempt fails; old value still served.
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
         }
 
         #[test]
-        fn test_watcher_creation_and_termination() {
-            let (_temp, schemas_dir, values_dir) = setup_watcher_test();
+        fn test_concurrent_reads_observe_new_values() {
+            use std::thread;
 
-            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let (initial_values, _) = registry.load_values_json(&values_dir).unwrap();
-            let values = Arc::new(ArcSwap::from_pointee(initial_values));
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = Arc::new(store_with_zero_threshold(&schemas_dir, &values_dir));
 
-            let mut watcher =
-                ValuesWatcher::new(&values_dir, Arc::clone(&registry), Arc::clone(&values))
-                    .expect("Failed to create watcher");
+            // Prime: every thread sees the initial value.
+            assert_eq!(store.load()["ns2"]["count"], json!(42));
 
-            assert!(watcher.is_alive());
-            watcher.stop();
-            assert!(!watcher.is_alive());
+            fs::write(
+                values_dir.join("ns2").join("values.json"),
+                r#"{"options": {"count": 7}}"#,
+            )
+            .unwrap();
+
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                let store = Arc::clone(&store);
+                handles.push(thread::spawn(move || {
+                    let guard = store.load();
+                    guard["ns2"]["count"].clone()
+                }));
+            }
+            for h in handles {
+                assert_eq!(h.join().unwrap(), json!(7));
+            }
         }
     }
     mod array_tests {

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -38,16 +38,13 @@
 //! not turn into an I/O storm.
 
 use arc_swap::ArcSwap;
-use chrono::{DateTime, Utc};
-use sentry::ClientOptions;
-use sentry::transports::DefaultTransportFactory;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, OnceLock,
+    Arc,
     atomic::{AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
@@ -65,39 +62,6 @@ const VALUES_FILE_NAME: &str = "values.json";
 /// refresh. A per-thread jitter of up to 1 s is added on top to spread the
 /// reload across threads.
 const REFRESH_THRESHOLD: Duration = Duration::from_secs(5);
-
-/// Dedicated Sentry DSN for sentry-options observability.
-/// This is separate from the host application's Sentry setup.
-#[cfg(not(test))]
-const SENTRY_OPTIONS_DSN: &str =
-    "https://d3598a07e9f23a9acee9e2718cfd17bd@o1.ingest.us.sentry.io/4510750163927040";
-
-/// Disabled DSN for tests - empty string creates a disabled client
-#[cfg(test)]
-const SENTRY_OPTIONS_DSN: &str = "";
-
-/// Lazily-initialized dedicated Sentry Hub for sentry-options.
-/// Uses a custom Client that is completely isolated from the host application's Sentry setup.
-/// In test mode, creates a disabled client (empty DSN) so no spans are sent.
-static SENTRY_HUB: OnceLock<Arc<sentry::Hub>> = OnceLock::new();
-
-fn get_sentry_hub() -> &'static Arc<sentry::Hub> {
-    SENTRY_HUB.get_or_init(|| {
-        let client = Arc::new(sentry::Client::from((
-            SENTRY_OPTIONS_DSN,
-            ClientOptions {
-                traces_sample_rate: 1.0,
-                // Explicitly set transport factory - required when not using sentry::init()
-                transport: Some(Arc::new(DefaultTransportFactory)),
-                ..Default::default()
-            },
-        )));
-        Arc::new(sentry::Hub::new(
-            Some(client),
-            Arc::new(sentry::Scope::default()),
-        ))
-    })
-}
 
 /// Production path where options are deployed via config map
 pub const PRODUCTION_OPTIONS_DIR: &str = "/etc/sentry-options";
@@ -736,7 +700,6 @@ impl ValuesStore {
     }
 
     fn refresh(&self, observed_last_ns: u64, now_ns: u64) {
-        let reload_start = Instant::now();
         let result = self.registry.load_values_json(&self.values_dir);
 
         // Publish the new snapshot before bumping the timestamp. The CAS below
@@ -747,14 +710,8 @@ impl ValuesStore {
         // but the ArcSwap still holds the previous snapshot on weakly ordered
         // architectures.
         match result {
-            Ok((new_values, generated_at_by_namespace)) => {
-                let namespaces: Vec<String> = new_values.keys().cloned().collect();
+            Ok((new_values, _)) => {
                 self.values.store(Arc::new(new_values));
-                emit_reload_spans(
-                    &namespaces,
-                    reload_start.elapsed(),
-                    &generated_at_by_namespace,
-                );
             }
             Err(e) => {
                 eprintln!(
@@ -786,41 +743,6 @@ fn stack_jitter_ns() -> u64 {
     let local = 0u8;
     let addr = &local as *const u8 as usize as u64;
     addr.wrapping_mul(0x9E37_79B9_7F4A_7C15) % 1_000_000_000
-}
-
-/// Emit a Sentry transaction per namespace with reload timing and propagation
-/// delay metrics. Uses the dedicated sentry-options hub isolated from the
-/// host application's Sentry setup.
-fn emit_reload_spans(
-    namespaces: &[String],
-    reload_duration: Duration,
-    generated_at_by_namespace: &HashMap<String, String>,
-) {
-    let hub = get_sentry_hub();
-    let applied_at = Utc::now();
-    let reload_duration_ms = reload_duration.as_secs_f64() * 1000.0;
-
-    for namespace in namespaces {
-        let mut tx_ctx = sentry::TransactionContext::new(namespace, "sentry_options.reload");
-        tx_ctx.set_sampled(true);
-
-        let transaction = hub.start_transaction(tx_ctx);
-        transaction.set_data("reload_duration_ms", reload_duration_ms.into());
-        transaction.set_data("applied_at", applied_at.to_rfc3339().into());
-
-        if let Some(ts) = generated_at_by_namespace.get(namespace) {
-            transaction.set_data("generated_at", ts.as_str().into());
-
-            if let Ok(generated_time) = DateTime::parse_from_rfc3339(ts) {
-                let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
-                    .num_milliseconds() as f64
-                    / 1000.0;
-                transaction.set_data("propagation_delay_secs", delay_secs.into());
-            }
-        }
-
-        transaction.finish();
-    }
 }
 
 #[cfg(test)]

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -316,7 +316,12 @@ impl SchemaRegistry {
 
             Self::validate_with_namespace_schema(&schema_data, schema_file, &namespace_validator)?;
             let schema = Self::parse_schema(schema_data, namespace, schema_file)?;
-            schemas_map.insert(namespace.to_string(), schema);
+            if schemas_map.insert(namespace.to_string(), schema).is_some() {
+                return Err(ValidationError::SchemaError {
+                    file: schema_file.to_path_buf(),
+                    message: format!("Duplicate namespace '{}'", namespace),
+                });
+            }
         }
 
         Ok(Self {
@@ -1011,6 +1016,32 @@ Error: \"version\" is a required property"
                 assert!(message.contains("\"description\" is a required property"));
             }
             _ => panic!("Expected SchemaError for missing description"),
+        }
+    }
+
+    #[test]
+    fn test_from_schemas_rejects_duplicate_namespace() {
+        let schema_a = r#"{
+            "version": "1.0",
+            "type": "object",
+            "properties": {
+                "opt": {"type": "string", "default": "a", "description": "A"}
+            }
+        }"#;
+        let schema_b = r#"{
+            "version": "1.0",
+            "type": "object",
+            "properties": {
+                "opt": {"type": "string", "default": "b", "description": "B"}
+            }
+        }"#;
+
+        let result = SchemaRegistry::from_schemas(&[("test", schema_a), ("test", schema_b)]);
+        match result {
+            Err(ValidationError::SchemaError { message, .. }) => {
+                assert!(message.contains("Duplicate namespace 'test'"));
+            }
+            _ => panic!("Expected SchemaError for duplicate namespace"),
         }
     }
 

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -21,15 +21,15 @@
 //!    snapshot. Otherwise:
 //!    a. Read all values files from disk and build the new map.
 //!    b. On success, publish the new map into the `ArcSwap`
-//!       (last-writer-wins under contention).
+//!    (last-writer-wins under contention).
 //!    c. `compare_exchange` `last_updated` from the previously-observed
-//!       value to `now` with `AcqRel`. The Release on the timestamp
-//!       publishes the prior `ArcSwap::store`: any reader that
-//!       Acquire-loads the bumped timestamp and short-circuits the
-//!       refresh is guaranteed to subsequently load the new snapshot.
+//!    value to `now` with `AcqRel`. The Release on the timestamp
+//!    publishes the prior `ArcSwap::store`: any reader that
+//!    Acquire-loads the bumped timestamp and short-circuits the
+//!    refresh is guaranteed to subsequently load the new snapshot.
 //!    d. On a parse/validation failure, leave the old map in place — the
-//!       bumped timestamp makes other threads back off until the next
-//!       window.
+//!    bumped timestamp makes other threads back off until the next
+//!    window.
 //!
 //! Multiple threads racing through the stale window will redundantly read
 //! files and publish; the last `ArcSwap::store` wins. The jitter spreads


### PR DESCRIPTION
 Replaces the `ValuesWatcher` polling thread with a refresh-on-read `ValuesStore`, and deletes the embedded `sentry::Hub` along with its `sentry` / `chrono` / `openssl` dependencies.

At a high level the motivation for both these changes is to:
- make `sentry-options` work in `init-before-fork` scenarios
- reduce additional threads
- simplify the codebase 

## Why remove the watcher thread

`ValuesWatcher` was disproportionately fragile:

- Fork hazard. A background thread doesn't survive fork(); the process struct kept a pid field plus a "join only if pid == process::id()" dance specifically to avoid wedging in pre-fork workers (uWSGI / gunicorn).
- Panic catching. Because there was no supervisor, the thread wrapped its body in `panic::catch_unwind(AssertUnwindSafe(…))` so a malformed values file wouldn't silently kill reloading. More code that exists only because there's a thread.
- Work for idle processes. A pod that never reads an option still woke up every 5s, stat'd a directory, and (on each `ConfigMap` rev) emitted Sentry telemetry.

## The new scheme

Every read calls `ValuesStore::load()`, which:

1. Reads `now` (monotonic, since a baseline `Instant`) and the `AtomicU64` `last_updated` with Acquire.
2. Computes a per-call jitter in [0, 1 s) from the address of a stack local — different threads have different stack bases, so values differ across threads. No `thread_local`, no allocations.
3. If `now - last_updated < threshold + jitter`, returns the current `ArcSwap` snapshot.
4. Otherwise: re-reads the values dir, `ArcSwap::stores` the new snapshot, then `compare_exchanges` the timestamp with AcqRel. The Release pairs with reader Acquires: a reader that observes the bumped timestamp and short-circuits its own refresh is guaranteed to subsequently load the new snapshot.

Concurrent threads that race through the stale window all read files; the last `ArcSwap::store` wins. Jitter spreads the threshold boundary so the herd doesn't cross together. On parse/validation failure the timestamp still gets bumped — broken values dirs back off for one window instead of inducing an I/O storm.

The main downside of this is that first option read in each 5s window pays the cost of doing IO to refresh the
options - potentially on the critical path. The normal case is fast: 1x `AtomicU64::load` + 1x `ArcSwap::load`.

## Why remove Sentry

1. Raises a large number of additional threading issues.
2. Adds a great deal of complexity + network.
3. Adds many dependancies: `sentry`, `chrono`, and `openssl`.

## Other smaller fixes
  - `SchemaRegistry::from_schemas` now errors on duplicate namespaces instead of silently overwriting (matches from_directory's behaviour).
  - `docs/architecture.md` updated to reflect that values live at `/etc/sentry-options/values/{namespace}/values.json`, not `/etc/sentry-options/{namespace}/values.json`.