### PR TITLE
feat(profiling): Adds `isset()` and `has()`

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -10,4 +10,6 @@ cargo bench --package sentry-options
 
 ```bash
 python clients/python/benches/bench_get.py
+python clients/python/benches/bench_has.py
+python clients/python/benches/bench_isset.py
 ```

--- a/clients/python/benches/bench_has.py
+++ b/clients/python/benches/bench_has.py
@@ -1,0 +1,27 @@
+"""Benchmarks for FeatureChecker.has() across various scenarios."""
+from __future__ import annotations
+
+import pyperf
+from sentry_options import FeatureContext
+from sentry_options import features
+from sentry_options import init
+
+NS = 'sentry-options-testing'
+
+init()
+checker = features(NS)
+
+ctx_match = FeatureContext({'organization_id': 123})
+ctx_disabled = FeatureContext({'organization_id': 123})
+ctx_rollout_zero = FeatureContext({'organization_id': 123})
+ctx_rollout_mid = FeatureContext({'is_trial': True})
+ctx_no_match = FeatureContext({'organization_id': 999})
+ctx_empty = FeatureContext({})
+
+runner = pyperf.Runner()
+runner.bench_func('has_enabled_100pct', checker.has, 'organizations:enabled-feature', ctx_match)
+runner.bench_func('has_disabled', checker.has, 'organizations:disabled-feature', ctx_disabled)
+runner.bench_func('has_rollout_zero', checker.has, 'organizations:rollout-zero', ctx_rollout_zero)
+runner.bench_func('has_rollout_50pct', checker.has, 'organizations:rollout-mid', ctx_rollout_mid)
+runner.bench_func('has_no_match', checker.has, 'organizations:enabled-feature', ctx_no_match)
+runner.bench_func('has_undefined', checker.has, 'organizations:nonexistent', ctx_empty)

--- a/clients/python/benches/bench_isset.py
+++ b/clients/python/benches/bench_isset.py
@@ -1,0 +1,15 @@
+"""Benchmarks for options.isset() with set and unset keys."""
+from __future__ import annotations
+
+import pyperf
+from sentry_options import init
+from sentry_options import options
+
+NS = 'sentry-options-testing'
+
+init()
+opts = options(NS)
+
+runner = pyperf.Runner()
+runner.bench_func('isset_set_key', opts.isset, 'example-option')
+runner.bench_func('isset_unset_key', opts.isset, 'string-option')

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,3 +22,11 @@ serde_json.workspace = true
 [[bench]]
 name = "options_bench"
 harness = false
+
+[[bench]]
+name = "features_bench"
+harness = false
+
+[[bench]]
+name = "isset_bench"
+harness = false

--- a/clients/rust/benches/features_bench.rs
+++ b/clients/rust/benches/features_bench.rs
@@ -1,0 +1,58 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use sentry_options::{FeatureChecker, FeatureContext, Options};
+use serde_json::json;
+use std::path::Path;
+
+const NS: &str = "sentry-options-testing";
+
+fn opts() -> &'static Options {
+    Box::leak(Box::new(
+        Options::from_directory(Path::new("../../sentry-options")).unwrap(),
+    ))
+}
+
+fn bench_has(c: &mut Criterion) {
+    let opts = opts();
+    let checker = FeatureChecker::new(NS.to_string(), opts);
+    let mut group = c.benchmark_group("has");
+
+    group.bench_function("enabled_100pct", |b| {
+        let mut ctx = FeatureContext::new();
+        ctx.insert("organization_id", json!(123));
+        b.iter(|| black_box(checker.has("organizations:enabled-feature", &ctx)));
+    });
+
+    group.bench_function("disabled", |b| {
+        let mut ctx = FeatureContext::new();
+        ctx.insert("organization_id", json!(123));
+        b.iter(|| black_box(checker.has("organizations:disabled-feature", &ctx)));
+    });
+
+    group.bench_function("rollout_zero", |b| {
+        let mut ctx = FeatureContext::new();
+        ctx.insert("organization_id", json!(123));
+        b.iter(|| black_box(checker.has("organizations:rollout-zero", &ctx)));
+    });
+
+    group.bench_function("rollout_50pct", |b| {
+        let mut ctx = FeatureContext::new();
+        ctx.insert("is_trial", json!(true));
+        b.iter(|| black_box(checker.has("organizations:rollout-mid", &ctx)));
+    });
+
+    group.bench_function("no_match", |b| {
+        let mut ctx = FeatureContext::new();
+        ctx.insert("organization_id", json!(999));
+        b.iter(|| black_box(checker.has("organizations:enabled-feature", &ctx)));
+    });
+
+    group.bench_function("undefined", |b| {
+        let ctx = FeatureContext::new();
+        b.iter(|| black_box(checker.has("organizations:nonexistent", &ctx)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_has);
+criterion_main!(benches);

--- a/clients/rust/benches/isset_bench.rs
+++ b/clients/rust/benches/isset_bench.rs
@@ -1,0 +1,27 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use sentry_options::Options;
+use std::path::Path;
+
+const NS: &str = "sentry-options-testing";
+
+fn opts() -> Options {
+    Options::from_directory(Path::new("../../sentry-options")).unwrap()
+}
+
+fn bench_isset(c: &mut Criterion) {
+    let opts = opts();
+    let mut group = c.benchmark_group("isset");
+
+    group.bench_function("set_key", |b| {
+        b.iter(|| black_box(opts.isset(NS, "example-option").unwrap()));
+    });
+
+    group.bench_function("unset_key", |b| {
+        b.iter(|| black_box(opts.isset(NS, "string-option").unwrap()));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_isset);
+criterion_main!(benches);


### PR DESCRIPTION
Rounding off our base profiling with `isset()` and `has()`. Preliminary results show that `has()` is 1000x faster right now compared to production