### PR TITLE
feat(ci): Create auto-bump SHA script

### DIFF
--- a/.github/scripts/bump_sha.py
+++ b/.github/scripts/bump_sha.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Bump a repo's SHA in sentry-options-automator's repos.json and open/update a PR."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def run(cmd: list[str], *, cwd: str | None = None, capture: bool = False) -> str:
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE if capture else None,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip() if capture else ''
+
+
+def main() -> None:
+    schemas_path = os.environ['SCHEMAS_PATH']
+    repo_name = os.environ['REPO_NAME']
+    new_sha = os.environ['NEW_SHA']
+    # -- Verify schemas directory exists in calling repo --
+    if not os.path.isdir(schemas_path):
+        print(f"::error::Schemas directory '{schemas_path}' not found")
+        sys.exit(1)
+
+    # -- Read repos.json --
+    repos_path = os.path.join('automator', 'repos.json')
+    with open(repos_path) as f:
+        data = json.load(f)
+
+    repos = data['repos']
+    if repo_name not in repos:
+        print(f"::error::Repository '{repo_name}' not found in repos.json")
+        sys.exit(1)
+
+    current_sha = repos[repo_name].get('sha', '')
+    if current_sha == new_sha:
+        print(f"SHA already up to date ({new_sha}), nothing to do.")
+        return
+
+    # -- Update SHA --
+    repos[repo_name]['sha'] = new_sha
+    with open(repos_path, 'w') as f:
+        json.dump(data, f, indent=2)
+        f.write('\n')
+    print(f"Updated {repo_name} SHA: {current_sha} -> {new_sha}")
+
+    # -- Commit and push --
+    short_sha = new_sha[:12]
+    branch = f"auto/bump-{repo_name}"
+    title = f"chore: bump {repo_name} schema SHA to {short_sha}"
+    cwd = 'automator'
+
+    run(['git', 'config', 'user.name', 'sentry-internal[bot]'], cwd=cwd)
+    run(['git', 'config', 'user.email', '38422159+sentry-internal[bot]@users.noreply.github.com'], cwd=cwd)
+    run(['git', 'checkout', '-B', branch], cwd=cwd)
+    run(['git', 'add', 'repos.json'], cwd=cwd)
+    run(['git', 'commit', '-m', title], cwd=cwd)
+    run(['git', 'push', '--force', 'origin', branch], cwd=cwd)
+
+    # -- Create or update PR --
+    existing_pr = run(
+        [
+            'gh', 'pr', 'list', '--repo', 'getsentry/sentry-options-automator',
+            '--head', branch, '--state', 'open',
+            '--json', 'number', '--jq', '.[0].number // empty',
+        ],
+        capture=True,
+    )
+
+    if existing_pr:
+        run([
+            'gh', 'pr', 'edit', existing_pr,
+            '--repo', 'getsentry/sentry-options-automator',
+            '--title', title, '--add-label', 'auto-merge',
+        ])
+        print(f"Updated existing PR #{existing_pr}")
+    else:
+        body = (
+            f"Automated SHA bump for **{repo_name}** to "
+            f"[`{short_sha}`](https://github.com/getsentry/{repo_name}/commit/{new_sha}).\n\n"
+            f"Triggered by merge to `main` in "
+            f"[getsentry/{repo_name}](https://github.com/getsentry/{repo_name})."
+        )
+        pr_url = run(
+            [
+                'gh', 'pr', 'create', '--repo', 'getsentry/sentry-options-automator',
+                '--head', branch, '--base', 'main',
+                '--title', title, '--body', body, '--label', 'auto-merge',
+            ],
+            capture=True,
+        )
+        print(f"Created PR: {pr_url}")
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/bump-sha.yml
+++ b/.github/workflows/bump-sha.yml
@@ -35,6 +35,14 @@ jobs:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
+      - name: Checkout sentry-options
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: getsentry/sentry-options
+          sparse-checkout: .github/scripts/bump_sha.py
+          sparse-checkout-cone-mode: false
+          path: sentry-options
+
       - name: Checkout sentry-options-automator
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -48,4 +56,4 @@ jobs:
           SCHEMAS_PATH: ${{ inputs.schemas-path }}
           REPO_NAME: ${{ github.event.repository.name }}
           NEW_SHA: ${{ github.sha }}
-        run: python3 .github/scripts/bump_sha.py
+        run: python3 sentry-options/.github/scripts/bump_sha.py

--- a/.github/workflows/bump-sha.yml
+++ b/.github/workflows/bump-sha.yml
@@ -91,8 +91,8 @@ jobs:
           # branch/PR instead of creating competing ones.
           BRANCH="auto/bump-${REPO_NAME}"
 
-          git config user.name "getsentry-bot"
-          git config user.email "bot@getsentry.com"
+          git config user.name "sentry-internal[bot]"
+          git config user.email "38422159+sentry-internal[bot]@users.noreply.github.com"
 
           # Create or reset the branch to current main with our change.
           git checkout -b "$BRANCH"

--- a/.github/workflows/bump-sha.yml
+++ b/.github/workflows/bump-sha.yml
@@ -15,6 +15,10 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail -ux {0}
+
 jobs:
   bump-sha:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
@@ -23,15 +27,6 @@ jobs:
     steps:
       - name: Checkout calling repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Verify schemas directory exists
-        env:
-          SCHEMAS_PATH: ${{ inputs.schemas-path }}
-        run: |
-          if [ ! -d "$SCHEMAS_PATH" ]; then
-            echo "::error::Schemas directory '$SCHEMAS_PATH' not found"
-            exit 1
-          fi
 
       - name: Generate token for sentry-options-automator
         id: app-token
@@ -47,91 +42,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: automator
 
-      - name: Update SHA in repos.json
-        id: update-sha
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          NEW_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          cd automator
-
-          CURRENT_SHA=$(jq -r --arg repo "$REPO_NAME" '.repos[$repo].sha // empty' repos.json)
-
-          if [ -z "$CURRENT_SHA" ]; then
-            echo "::error::Repository '$REPO_NAME' not found in repos.json"
-            exit 1
-          fi
-
-          if [ "$CURRENT_SHA" = "$NEW_SHA" ]; then
-            echo "SHA is already up to date ($NEW_SHA), nothing to do."
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          jq --arg repo "$REPO_NAME" --arg sha "$NEW_SHA" \
-            '.repos[$repo].sha = $sha' repos.json > repos.json.tmp
-          mv repos.json.tmp repos.json
-
-          echo "updated=true" >> "$GITHUB_OUTPUT"
-          echo "Updated $REPO_NAME SHA: $CURRENT_SHA -> $NEW_SHA"
-
-      - name: Create or update PR in sentry-options-automator
-        if: steps.update-sha.outputs.updated == 'true'
+      - name: Bump SHA and open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SCHEMAS_PATH: ${{ inputs.schemas-path }}
           REPO_NAME: ${{ github.event.repository.name }}
           NEW_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          cd automator
-
-          SHORT_SHA="${NEW_SHA:0:12}"
-          # Fixed branch name per repo — rapid merges update the same
-          # branch/PR instead of creating competing ones.
-          BRANCH="auto/bump-${REPO_NAME}"
-
-          git config user.name "sentry-internal[bot]"
-          git config user.email "38422159+sentry-internal[bot]@users.noreply.github.com"
-
-          # Create or reset the branch to current main with our change.
-          git checkout -b "$BRANCH"
-          git add repos.json
-          git commit -m "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}"
-          git push --force origin "$BRANCH"
-
-          # If a PR already exists for this branch, it auto-updates from
-          # the force-push. Just add the auto-merge label in case a
-          # previous attempt had it removed.
-          EXISTING_PR=$(gh pr list \
-            --repo getsentry/sentry-options-automator \
-            --head "$BRANCH" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-
-          if [ -n "$EXISTING_PR" ]; then
-            gh pr edit "$EXISTING_PR" \
-              --repo getsentry/sentry-options-automator \
-              --title "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}" \
-              --add-label "auto-merge"
-            echo "Updated existing PR #${EXISTING_PR}"
-            exit 0
-          fi
-
-          PR_BODY=$(cat <<EOF
-          Automated SHA bump for **${REPO_NAME}** to [\`${SHORT_SHA}\`](https://github.com/getsentry/${REPO_NAME}/commit/${NEW_SHA}).
-
-          Triggered by merge to \`main\` in [getsentry/${REPO_NAME}](https://github.com/getsentry/${REPO_NAME}).
-          EOF
-          )
-
-          PR_URL=$(gh pr create \
-            --repo getsentry/sentry-options-automator \
-            --head "$BRANCH" \
-            --base main \
-            --title "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}" \
-            --body "$PR_BODY" \
-            --label "auto-merge")
-
-          echo "Created PR: ${PR_URL}"
+        run: python3 .github/scripts/bump_sha.py

--- a/.github/workflows/bump-sha.yml
+++ b/.github/workflows/bump-sha.yml
@@ -1,0 +1,137 @@
+name: Bump SHA in sentry-options-automator
+
+on:
+  workflow_call:
+    inputs:
+      schemas-path:
+        description: "Path to the schemas directory (used to verify schema files exist)"
+        type: string
+        default: "sentry-options/schemas"
+
+# Serialize per-repo so two rapid merges don't race.
+concurrency:
+  group: bump-sha-${{ github.repository }}
+
+permissions:
+  contents: read
+
+jobs:
+  bump-sha:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout calling repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Verify schemas directory exists
+        env:
+          SCHEMAS_PATH: ${{ inputs.schemas-path }}
+        run: |
+          if [ ! -d "$SCHEMAS_PATH" ]; then
+            echo "::error::Schemas directory '$SCHEMAS_PATH' not found"
+            exit 1
+          fi
+
+      - name: Generate token for sentry-options-automator
+        id: app-token
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+        with:
+          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      - name: Checkout sentry-options-automator
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: getsentry/sentry-options-automator
+          token: ${{ steps.app-token.outputs.token }}
+          path: automator
+
+      - name: Update SHA in repos.json
+        id: update-sha
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd automator
+
+          CURRENT_SHA=$(jq -r --arg repo "$REPO_NAME" '.repos[$repo].sha // empty' repos.json)
+
+          if [ -z "$CURRENT_SHA" ]; then
+            echo "::error::Repository '$REPO_NAME' not found in repos.json"
+            exit 1
+          fi
+
+          if [ "$CURRENT_SHA" = "$NEW_SHA" ]; then
+            echo "SHA is already up to date ($NEW_SHA), nothing to do."
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          jq --arg repo "$REPO_NAME" --arg sha "$NEW_SHA" \
+            '.repos[$repo].sha = $sha' repos.json > repos.json.tmp
+          mv repos.json.tmp repos.json
+
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+          echo "Updated $REPO_NAME SHA: $CURRENT_SHA -> $NEW_SHA"
+
+      - name: Create or update PR in sentry-options-automator
+        if: steps.update-sha.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd automator
+
+          SHORT_SHA="${NEW_SHA:0:12}"
+          # Fixed branch name per repo — rapid merges update the same
+          # branch/PR instead of creating competing ones.
+          BRANCH="auto/bump-${REPO_NAME}"
+
+          git config user.name "getsentry-bot"
+          git config user.email "bot@getsentry.com"
+
+          # Create or reset the branch to current main with our change.
+          git checkout -b "$BRANCH"
+          git add repos.json
+          git commit -m "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}"
+          git push --force origin "$BRANCH"
+
+          # If a PR already exists for this branch, it auto-updates from
+          # the force-push. Just add the auto-merge label in case a
+          # previous attempt had it removed.
+          EXISTING_PR=$(gh pr list \
+            --repo getsentry/sentry-options-automator \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --repo getsentry/sentry-options-automator \
+              --title "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}" \
+              --add-label "auto-merge"
+            echo "Updated existing PR #${EXISTING_PR}"
+            exit 0
+          fi
+
+          PR_BODY=$(cat <<EOF
+          Automated SHA bump for **${REPO_NAME}** to [\`${SHORT_SHA}\`](https://github.com/getsentry/${REPO_NAME}/commit/${NEW_SHA}).
+
+          Triggered by merge to \`main\` in [getsentry/${REPO_NAME}](https://github.com/getsentry/${REPO_NAME}).
+          EOF
+          )
+
+          PR_URL=$(gh pr create \
+            --repo getsentry/sentry-options-automator \
+            --head "$BRANCH" \
+            --base main \
+            --title "chore: bump ${REPO_NAME} schema SHA to ${SHORT_SHA}" \
+            --body "$PR_BODY" \
+            --label "auto-merge")
+
+          echo "Created PR: ${PR_URL}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py312-plus]

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -323,6 +323,34 @@ jobs:
       schemas-path: sentry-options/schemas
 ```
 
+#### 8. Add Automatic SHA Bump
+
+This workflow automatically bumps the schema SHA in `sentry-options-automator` when
+schema changes merge to main, so you don't have to create that PR manually.
+
+`.github/workflows/bump-sentry-options-sha.yml`:
+```yaml
+name: Bump sentry-options SHA
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sentry-options/schemas/**'
+
+jobs:
+  bump-sha:
+    uses: getsentry/sentry-options/.github/workflows/bump-sha.yml@main
+    secrets: inherit
+    with:
+      schemas-path: sentry-options/schemas
+```
+
+When a PR that touches schemas merges to main, this creates a PR in
+`sentry-options-automator` updating `repos.json` with the new commit SHA.
+The PR is labeled `auto-merge` and will be automatically approved and
+squash-merged once CI passes.
+
 ### Phase 2: sentry-options-automator Changes
 
 **Dependency:** Schema must exist in service repo first (CI fetches it for validation).
@@ -350,7 +378,8 @@ Add your service to `repos.json`:
 - `path` - Path to schemas directory within the repo (contains `{namespace}/schema.json`)
 - `sha` - Commit SHA (pinned for reproducibility)
 
-**Important:** When you update your schema, you must also update the SHA in repos.json to point to the commit containing the new schema.
+If your service repo has the auto SHA bump workflow (step 8 above), the SHA
+will be kept up to date automatically when schema changes merge.
 
 #### 2. Create Values File
 
@@ -370,23 +399,26 @@ Region-specific overrides in `option-values/{namespace}/{region}/values.yaml`.
 When you update your schema in the service repo:
 
 1. Merge schema change to service repo (e.g., `getsentry/seer`)
-2. Get the merge commit SHA
-3. Update `repos.json` in sentry-options-automator with new SHA
-4. If values need to change, update them in same PR
+2. SHA bump in `sentry-options-automator` happens automatically via the bump-sha workflow
+3. If values need to change, create a PR in the automator repo with the updated values
 
 ```
 Service Repo                    sentry-options-automator
 ───────────                    ─────────────────────────
-PR: Update schema.json    →    PR: Update repos.json SHA
-        ↓                              ↓
-    Merge                          + Update values if needed
-        ↓                              ↓
-   (commit abc123)                  Merge
+PR: Update schema.json
+        ↓
+    Merge
+        ↓
+   (commit abc123)         →    Auto PR: Update repos.json SHA
                                        ↓
-                               CI validates values against new schema
+                               Auto-merge after CI passes
                                        ↓
                                CD deploys new ConfigMaps
 ```
+
+If you need to set option values alongside the schema change, create a
+separate PR in the automator repo for the values. The auto-bumped SHA
+PR will merge first, then your values PR can merge after.
 
 ### Phase 3: ops Repo Changes
 


### PR DESCRIPTION
https://linear.app/getsentry/issue/DI-1965/sha-auto-bump-script

This reusable action, once imported in your repo, will automatically bump the SHA of your repo in `repos.json`.

## Important
- I haven't verified if this token has write access. If it does not, we will need to file some stuff with security to get an app or change the permissions of this token.