### PR TITLE
feat(ci): Warn instead of fail when values are orphaned

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -101,9 +101,7 @@ jobs:
             --root ./option-values)
 
           if [ -n "$RESULT" ]; then
-            echo "Cannot delete options that are still defined in sentry-options-automator:"
-            echo "$RESULT"
-            exit 1
+            echo "::warning::The following deleted options still have values in sentry-options-automator: $RESULT"
+          else
+            echo "All deleted options are safe to remove"
           fi
-
-          echo "All deleted options are safe to remove"

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -143,7 +143,7 @@ The CI enforces these rules when you modify schemas:
 |--------|---------|
 | Add new options | ✅ |
 | Add new namespaces | ✅ |
-| Remove options | ✅ (CI blocks if still in use in automator) |
+| Remove options | ✅ (CI warns if still in use in automator) |
 | Remove namespaces | ❌ |
 | Change option types | ❌ |
 | Change default values | ❌ |


### PR DESCRIPTION
The current workflow for the new sentry-options when deleting an option involves:
1. Remove its usage in code (`.get()`)
2. Remove the value in `sentry-options-automator` (`values.yaml`)
3. Remove its definition in the schema (in the service repo)

This is a 3 step process that requires 3 separate PRs and is annoying for product engineers. By going back to how the old system works, this becomes:
1. Remove its usage and definition in code
2. Have the agent clean up its value in `sentry-options-automator`

This brings it down to 1 PR, much easier to digest.

We don't lose much safety because the only thing we were guarding against were stale values in the automator repo. We already have workaround for this today and see no problems, so I see no reason why we need to build extra guardrails. 

## stuff changed
- Made it so the workflow only WARNS insted of FAILS CI
- Updated the docs a tiny bit