### PR TITLE
feat(metrics): Allow clients to hook into propagation time metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,12 +207,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1479,6 +1481,7 @@ version = "1.0.13"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "chrono",
  "jsonschema",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ tempfile = "3.23.0"
 jsonschema = "0.36.0"
 sha1 = "0.10"
 arc-swap = "1.9.1"
+chrono = { version = "0.4.45", default-features = false, features = ["std", "clock"] }

--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Callable, Union
 
 _Primitive = Union[str, int, float, bool]
 _Object = dict[str, _Primitive]
 OptionValue = Union[_Primitive, _Object, list[Union[_Primitive, _Object]]]
 
-def init() -> None: ...
+def init(on_propagation: Callable[[str, float], None] | None = None) -> None: ...
 """
 Initialize the options extension with schema and
 values defined in environment variables or production paths.
+
+Parameters
+----------
+on_propagation : callable, optional
+    Callback invoked when values are refreshed with a new ``generated_at``
+    timestamp. Receives ``(namespace: str, delay_secs: float)``.
 """
 
 def options(namespace: str) -> NamespaceOptions: ...

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -12,31 +12,6 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 use serde_json::Value;
 
-/// Wrapper that lets a Python callable be invoked from the Rust propagation
-/// callback (which runs on the thread that triggers a values refresh).
-/// The GIL is acquired only for the duration of the call.
-struct PyPropagationCallback {
-    callback: PyObject,
-}
-
-// SAFETY: The `PyObject` is only accessed inside `Python::with_gil`, which
-// acquires the GIL before touching the reference-counted pointer. `Send` is
-// safe because moving the wrapper to another thread does not access the
-// `PyObject`. `Sync` is safe because concurrent calls to `call()` each
-// independently acquire the GIL, so no unsynchronized access occurs.
-unsafe impl Send for PyPropagationCallback {}
-unsafe impl Sync for PyPropagationCallback {}
-
-impl PyPropagationCallback {
-    fn call(&self, namespace: &str, delay_secs: f64) {
-        Python::with_gil(|py| {
-            if let Err(e) = self.callback.call1(py, (namespace, delay_secs)) {
-                e.print(py);
-            }
-        });
-    }
-}
-
 // Global options instance
 static GLOBAL_OPTIONS: OnceLock<RustOptions> = OnceLock::new();
 
@@ -222,13 +197,16 @@ fn init(on_propagation: Option<PyObject>) -> PyResult<()> {
         return Ok(());
     }
     let opts = match on_propagation {
-        Some(cb) => {
-            let wrapper = PyPropagationCallback { callback: cb };
-            RustOptions::new_with_propagation_callback(Box::new(move |ns, delay| {
-                wrapper.call(ns, delay);
-            }))
-            .map_err(options_err)?
-        }
+        // `Py<PyAny>` is `Send + Sync`; the closure re-acquires the GIL for the
+        // call, so the callback can run on whichever thread triggers a refresh.
+        Some(cb) => RustOptions::new_with_propagation_callback(Box::new(move |ns, delay| {
+            Python::with_gil(|py| {
+                if let Err(e) = cb.call1(py, (ns, delay)) {
+                    e.print(py);
+                }
+            });
+        }))
+        .map_err(options_err)?,
         None => RustOptions::new().map_err(options_err)?,
     };
     let _ = GLOBAL_OPTIONS.set(opts);

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -192,7 +192,7 @@ impl PyFeatureChecker {
 /// `(namespace: str, delay_secs: float)`.
 #[pyfunction]
 #[pyo3(signature = (on_propagation=None))]
-fn init(on_propagation: Option<PyObject>) -> PyResult<()> {
+fn init(on_propagation: Option<Py<PyAny>>) -> PyResult<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
     }
@@ -200,7 +200,7 @@ fn init(on_propagation: Option<PyObject>) -> PyResult<()> {
         // `Py<PyAny>` is `Send + Sync`; the closure re-acquires the GIL for the
         // call, so the callback can run on whichever thread triggers a refresh.
         Some(cb) => RustOptions::new_with_propagation_callback(Box::new(move |ns, delay| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 if let Err(e) = cb.call1(py, (ns, delay)) {
                     e.print(py);
                 }

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -12,6 +12,27 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 use serde_json::Value;
 
+/// Wrapper that lets a Python callable be invoked from the Rust propagation
+/// callback (which runs on the thread that triggers a values refresh).
+/// The GIL is acquired only for the duration of the call.
+struct PyPropagationCallback {
+    callback: PyObject,
+}
+
+// SAFETY: The PyObject is only accessed while holding the GIL (inside `call`).
+unsafe impl Send for PyPropagationCallback {}
+unsafe impl Sync for PyPropagationCallback {}
+
+impl PyPropagationCallback {
+    fn call(&self, namespace: &str, delay_secs: f64) {
+        Python::with_gil(|py| {
+            if let Err(e) = self.callback.call1(py, (namespace, delay_secs)) {
+                e.print(py);
+            }
+        });
+    }
+}
+
 // Global options instance
 static GLOBAL_OPTIONS: OnceLock<RustOptions> = OnceLock::new();
 
@@ -186,12 +207,26 @@ impl PyFeatureChecker {
 
 /// Initialize global options using fallback chain: SENTRY_OPTIONS_DIR env var,
 /// then /etc/sentry-options if it exists, otherwise sentry-options/.
+///
+/// Optionally accepts an `on_propagation` callback that fires whenever values
+/// are refreshed with a new `generated_at` timestamp. The callback receives
+/// `(namespace: str, delay_secs: float)`.
 #[pyfunction]
-fn init() -> PyResult<()> {
+#[pyo3(signature = (on_propagation=None))]
+fn init(on_propagation: Option<PyObject>) -> PyResult<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
     }
-    let opts = RustOptions::new().map_err(options_err)?;
+    let opts = match on_propagation {
+        Some(cb) => {
+            let wrapper = PyPropagationCallback { callback: cb };
+            RustOptions::new_with_propagation_callback(Box::new(move |ns, delay| {
+                wrapper.call(ns, delay);
+            }))
+            .map_err(options_err)?
+        }
+        None => RustOptions::new().map_err(options_err)?,
+    };
     let _ = GLOBAL_OPTIONS.set(opts);
     Ok(())
 }

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -19,7 +19,11 @@ struct PyPropagationCallback {
     callback: PyObject,
 }
 
-// SAFETY: The PyObject is only accessed while holding the GIL (inside `call`).
+// SAFETY: The `PyObject` is only accessed inside `Python::with_gil`, which
+// acquires the GIL before touching the reference-counted pointer. `Send` is
+// safe because moving the wrapper to another thread does not access the
+// `PyObject`. `Sync` is safe because concurrent calls to `call()` each
+// independently acquire the GIL, so no unsynchronized access occurs.
 unsafe impl Send for PyPropagationCallback {}
 unsafe impl Sync for PyPropagationCallback {}
 

--- a/clients/python/tests/propagation_test.py
+++ b/clients/python/tests/propagation_test.py
@@ -1,0 +1,167 @@
+"""E2E tests for the propagation time callback through the Python client.
+
+Each test spins up a subprocess with its own ``SENTRY_OPTIONS_DIR`` so the
+Rust ``OnceLock`` starts fresh and ``init(on_propagation=...)`` can register
+a real Python callback.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+# 5 s refresh threshold + up to 1 s jitter + margin
+REFRESH_WAIT = 7
+
+
+def _make_options_dir(root: Path, *, generated_at: str | None = None) -> Path:
+    options_dir = root / 'opts'
+    schemas_dir = options_dir / 'schemas' / 'test-ns'
+    values_dir = options_dir / 'values' / 'test-ns'
+    schemas_dir.mkdir(parents=True)
+    values_dir.mkdir(parents=True)
+
+    schemas_dir.joinpath('schema.json').write_text(
+        json.dumps(
+            {
+                'version': '1.0',
+                'type': 'object',
+                'properties': {
+                    'enabled': {
+                        'type': 'boolean',
+                        'default': False,
+                        'description': 'Enabled',
+                    },
+                },
+            },
+        ),
+    )
+
+    values: dict = {'options': {'enabled': True}}
+    if generated_at is not None:
+        values['generated_at'] = generated_at
+    values_dir.joinpath('values.json').write_text(json.dumps(values))
+
+    return options_dir
+
+
+def _run(script: str, options_dir: Path, timeout: int = 30, **env_extra: str) -> None:
+    env = os.environ.copy()
+    env['SENTRY_OPTIONS_DIR'] = str(options_dir)
+    env.update(env_extra)
+    result = subprocess.run(
+        [sys.executable, '-c', dedent(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, (
+        f"Script failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> None:
+    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
+    _run(
+        f"""\
+        import json, time
+        from sentry_options import init, options
+
+        results = []
+        init(on_propagation=lambda ns, delay: results.append((ns, delay)))
+        assert options("test-ns").get("enabled") is True
+
+        time.sleep({REFRESH_WAIT})
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
+        options("test-ns").get("enabled")
+
+        assert len(results) == 1, f"Expected 1 callback, got {{len(results)}}: {{results}}"
+        ns, delay = results[0]
+        assert ns == "test-ns"
+        assert isinstance(delay, float)
+        assert delay > 0.0
+        """,
+        options_dir,
+    )
+
+
+def test_propagation_callback_not_called_without_generated_at(tmp_path: Path) -> None:
+    _run(
+        f"""\
+        import time
+        from sentry_options import init, options
+
+        results = []
+        init(on_propagation=lambda ns, delay: results.append((ns, delay)))
+        options("test-ns").get("enabled")
+
+        time.sleep({REFRESH_WAIT})
+        options("test-ns").get("enabled")
+
+        assert len(results) == 0, f"Expected no callbacks, got {{len(results)}}"
+        """,
+        _make_options_dir(tmp_path),
+    )
+
+
+def test_propagation_callback_exception_does_not_crash(tmp_path: Path) -> None:
+    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
+    _run(
+        f"""\
+        import json, time
+        from sentry_options import init, options
+
+        def boom(ns, delay):
+            raise RuntimeError("callback boom")
+
+        init(on_propagation=boom)
+        assert options("test-ns").get("enabled") is True
+
+        time.sleep({REFRESH_WAIT})
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
+
+        val = options("test-ns").get("enabled")
+        assert val is True
+        """,
+        options_dir,
+    )
+
+
+def test_propagation_callback_receives_multiple_updates(tmp_path: Path) -> None:
+    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:00:00+00:00')
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
+    _run(
+        f"""\
+        import json, time
+        from sentry_options import init, options
+
+        results = []
+        init(on_propagation=lambda ns, delay: results.append((ns, delay)))
+        options("test-ns").get("enabled")
+
+        time.sleep({REFRESH_WAIT})
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
+        options("test-ns").get("enabled")
+        assert len(results) == 1, f"After 1st update: expected 1, got {{len(results)}}"
+
+        time.sleep({REFRESH_WAIT})
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T20:00:00+00:00"}}, f)
+        options("test-ns").get("enabled")
+        assert len(results) == 2, f"After 2nd update: expected 2, got {{len(results)}}"
+
+        assert all(ns == "test-ns" for ns, _ in results)
+        assert all(d > 0.0 for _, d in results)
+        """,
+        options_dir,
+        timeout=45,
+    )

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -7,6 +7,7 @@ pub use features::{FeatureChecker, FeatureContext, features};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
+pub use sentry_options_validation::PropagationCallback;
 use sentry_options_validation::{
     SchemaRegistry, ValidationError, ValuesStore, resolve_options_dir,
 };
@@ -47,6 +48,14 @@ impl Options {
         Self::from_directory(&resolve_options_dir())
     }
 
+    /// Like [`new`], but with a propagation callback that fires `(namespace, delay_secs)`
+    /// whenever values are refreshed with a new `generated_at` timestamp.
+    pub fn new_with_propagation_callback(callback: PropagationCallback) -> Result<Self> {
+        let dir = resolve_options_dir();
+        let registry = SchemaRegistry::from_directory(&dir.join("schemas"))?;
+        Self::with_registry_values_and_callback(registry, &dir.join("values"), callback)
+    }
+
     /// Load options from a specific directory (useful for testing).
     /// Expects `{base_dir}/schemas/` and `{base_dir}/values/` subdirectories.
     pub fn from_directory(base_dir: &Path) -> Result<Self> {
@@ -63,6 +72,16 @@ impl Options {
 
     fn with_registry_and_values(registry: SchemaRegistry, values_dir: &Path) -> Result<Self> {
         let store = ValuesStore::new(Arc::new(registry), values_dir)?;
+        Ok(Self { store })
+    }
+
+    fn with_registry_values_and_callback(
+        registry: SchemaRegistry,
+        values_dir: &Path,
+        callback: PropagationCallback,
+    ) -> Result<Self> {
+        let store =
+            ValuesStore::with_propagation_callback(Arc::new(registry), values_dir, callback)?;
         Ok(Self { store })
     }
 
@@ -146,6 +165,20 @@ pub fn init() -> Result<()> {
         return Ok(());
     }
     let opts = Options::new()?;
+    let _ = GLOBAL_OPTIONS.set(opts);
+    Ok(())
+}
+
+/// Like [`init`], but with a callback that fires whenever values are refreshed
+/// from disk with a new `generated_at` timestamp. The callback receives
+/// `(namespace, delay_secs)`.
+pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<()> {
+    if GLOBAL_OPTIONS.get().is_some() {
+        return Ok(());
+    }
+    let dir = resolve_options_dir();
+    let registry = SchemaRegistry::from_directory(&dir.join("schemas"))?;
+    let opts = Options::with_registry_values_and_callback(registry, &dir.join("values"), callback)?;
     let _ = GLOBAL_OPTIONS.set(opts);
     Ok(())
 }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -53,35 +53,33 @@ impl Options {
     pub fn new_with_propagation_callback(callback: PropagationCallback) -> Result<Self> {
         let dir = resolve_options_dir();
         let registry = SchemaRegistry::from_directory(&dir.join("schemas"))?;
-        Self::with_registry_values_and_callback(registry, &dir.join("values"), callback)
+        Self::with_registry_and_values(registry, &dir.join("values"), Some(callback))
     }
 
     /// Load options from a specific directory (useful for testing).
     /// Expects `{base_dir}/schemas/` and `{base_dir}/values/` subdirectories.
     pub fn from_directory(base_dir: &Path) -> Result<Self> {
         let registry = SchemaRegistry::from_directory(&base_dir.join("schemas"))?;
-        Self::with_registry_and_values(registry, &base_dir.join("values"))
+        Self::with_registry_and_values(registry, &base_dir.join("values"), None)
     }
 
     /// Load options with schemas provided as in-memory JSON strings.
     /// Values are loaded from disk using the standard fallback chain.
     pub fn from_schemas(schemas: &[(&str, &str)]) -> Result<Self> {
         let registry = SchemaRegistry::from_schemas(schemas)?;
-        Self::with_registry_and_values(registry, &resolve_options_dir().join("values"))
+        Self::with_registry_and_values(registry, &resolve_options_dir().join("values"), None)
     }
 
-    fn with_registry_and_values(registry: SchemaRegistry, values_dir: &Path) -> Result<Self> {
-        let store = ValuesStore::new(Arc::new(registry), values_dir)?;
-        Ok(Self { store })
-    }
-
-    fn with_registry_values_and_callback(
+    fn with_registry_and_values(
         registry: SchemaRegistry,
         values_dir: &Path,
-        callback: PropagationCallback,
+        callback: Option<PropagationCallback>,
     ) -> Result<Self> {
-        let store =
-            ValuesStore::with_propagation_callback(Arc::new(registry), values_dir, callback)?;
+        let registry = Arc::new(registry);
+        let store = match callback {
+            Some(cb) => ValuesStore::with_propagation_callback(registry, values_dir, cb)?,
+            None => ValuesStore::new(registry, values_dir)?,
+        };
         Ok(Self { store })
     }
 
@@ -176,9 +174,7 @@ pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<(
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
     }
-    let dir = resolve_options_dir();
-    let registry = SchemaRegistry::from_directory(&dir.join("schemas"))?;
-    let opts = Options::with_registry_values_and_callback(registry, &dir.join("values"), callback)?;
+    let opts = Options::new_with_propagation_callback(callback)?;
     let _ = GLOBAL_OPTIONS.set(opts);
     Ok(())
 }

--- a/sentry-options-cli/Cargo.toml
+++ b/sentry-options-cli/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "CLI tool for sentry-options for validation of schema and values"
 
 [dependencies]
-chrono = { version = "0.4.43", default-features = false, features = ["std", "clock"] }
+chrono.workspace = true
 clap = { version = "4.5.51", features = ["derive", "env"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -14,6 +14,7 @@ thiserror.workspace = true
 jsonschema.workspace = true
 tempfile.workspace = true
 arc-swap.workspace = true
+chrono = { version = "0.4.45", features = ["clock"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sentry-options-validation/Cargo.toml
+++ b/sentry-options-validation/Cargo.toml
@@ -14,7 +14,7 @@ thiserror.workspace = true
 jsonschema.workspace = true
 tempfile.workspace = true
 arc-swap.workspace = true
-chrono = { version = "0.4.45", features = ["clock"] }
+chrono.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -746,10 +746,10 @@ impl ValuesStore {
         // Reversing the order opens a window where the timestamp says "fresh"
         // but the ArcSwap still holds the previous snapshot on weakly ordered
         // architectures.
-        match result {
-            Ok((new_values, new_generated_at)) => {
+        let new_generated_at = match result {
+            Ok((new_values, generated_at)) => {
                 self.values.store(Arc::new(new_values));
-                self.emit_propagation_events(new_generated_at);
+                Some(generated_at)
             }
             Err(e) => {
                 eprintln!(
@@ -757,8 +757,9 @@ impl ValuesStore {
                     self.values_dir.display(),
                     e
                 );
+                None
             }
-        }
+        };
 
         // Bump the timestamp regardless of success. On failure, the bumped
         // timestamp keeps subsequent reads from hammering the filesystem until
@@ -770,36 +771,46 @@ impl ValuesStore {
             Ordering::AcqRel,
             Ordering::Relaxed,
         );
+
+        // Fire the propagation callback after the CAS so other threads see a
+        // fresh timestamp and don't redundantly re-read from disk while a
+        // potentially slow callback (e.g. Python/GIL) executes.
+        if let Some(generated_at) = new_generated_at {
+            self.emit_propagation_events(generated_at);
+        }
     }
 
-    /// Compare new `generated_at` timestamps against the last known ones.
-    /// For each namespace where the timestamp changed, invoke the callback
-    /// with the propagation delay. Uses ArcSwap for fork-safe, lock-free access.
+    /// Invoke the propagation callback for each namespace whose `generated_at`
+    /// changed since the last refresh. Skips entirely when no callback is
+    /// registered or when nothing changed (avoids an Arc allocation every cycle).
     fn emit_propagation_events(&self, new_generated_at: HashMap<String, String>) {
-        let callback = match &self.on_propagation {
-            Some(cb) => cb,
-            None => {
-                // Still update the stored timestamps so a callback added later
-                // doesn't see stale state.
-                self.last_generated_at.store(Arc::new(new_generated_at));
-                return;
-            }
-        };
-
-        let applied_at = Utc::now();
         let last = self.last_generated_at.load();
+        if *last.as_ref() == new_generated_at {
+            return;
+        }
 
-        for (namespace, new_ts) in &new_generated_at {
-            let changed = last.get(namespace).is_none_or(|old_ts| old_ts != new_ts);
-            if !changed {
-                continue;
-            }
+        if let Some(callback) = &self.on_propagation {
+            let applied_at = Utc::now();
+            for (namespace, new_ts) in &new_generated_at {
+                let changed = last.get(namespace).is_none_or(|old_ts| old_ts != new_ts);
+                if !changed {
+                    continue;
+                }
 
-            if let Ok(generated_time) = DateTime::parse_from_rfc3339(new_ts) {
-                let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
-                    .num_milliseconds() as f64
-                    / 1000.0;
-                callback(namespace, delay_secs.max(0.0));
+                match DateTime::parse_from_rfc3339(new_ts) {
+                    Ok(generated_time) => {
+                        let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
+                            .num_milliseconds() as f64
+                            / 1000.0;
+                        callback(namespace, delay_secs.max(0.0));
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Failed to parse generated_at for namespace {}: {} ({})",
+                            namespace, new_ts, e
+                        );
+                    }
+                }
             }
         }
 

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -767,47 +767,40 @@ impl ValuesStore {
         // Fire the propagation callback after the CAS so other threads see a
         // fresh timestamp and don't redundantly re-read from disk while a
         // potentially slow callback (e.g. Python/GIL) executes.
-        if let Some(generated_at) = new_generated_at {
-            self.emit_propagation_events(generated_at);
-        }
-    }
-
-    /// Invoke the propagation callback for each namespace whose `generated_at`
-    /// changed since the last refresh. Skips entirely when no callback is
-    /// registered or when nothing changed.
-    fn emit_propagation_events(&self, new_generated_at: HashMap<String, String>) {
-        let last = self.last_generated_at.load();
-        if *last.as_ref() == new_generated_at {
-            return;
-        }
-
-        if let Some(callback) = &self.on_propagation {
-            let applied_at = Utc::now();
-            for (namespace, new_ts) in &new_generated_at {
-                let changed = last.get(namespace).is_none_or(|old_ts| old_ts != new_ts);
-                if !changed {
-                    continue;
-                }
-
-                match DateTime::parse_from_rfc3339(new_ts) {
-                    Ok(generated_time) => {
-                        let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
-                            .num_milliseconds() as f64
-                            / 1000.0;
-                        callback(namespace, delay_secs.max(0.0));
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "Failed to parse generated_at for namespace {}: {} ({})",
-                            namespace, new_ts, e
-                        );
+        if let Some(new_generated_at) = new_generated_at {
+            let last = self.last_generated_at.load();
+            if *last.as_ref() != new_generated_at {
+                if let Some(callback) = &self.on_propagation {
+                    let applied_at = Utc::now();
+                    for (ns, ts) in &new_generated_at {
+                        if last.get(ns).is_some_and(|old| old == ts) {
+                            continue;
+                        }
+                        match propagation_delay_secs(&applied_at, ts) {
+                            Some(delay) => {
+                                if let Err(e) =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        callback(ns, delay)
+                                    }))
+                                {
+                                    eprintln!("Propagation callback panicked for {ns}: {:?}", e);
+                                }
+                            }
+                            None => eprintln!("Bad generated_at for {ns}: {ts}"),
+                        }
                     }
                 }
+                self.last_generated_at.store(Arc::new(new_generated_at));
             }
         }
-
-        self.last_generated_at.store(Arc::new(new_generated_at));
     }
+}
+
+/// Parse an RFC3339 timestamp and return the delay in seconds from then to `now`.
+fn propagation_delay_secs(now: &DateTime<Utc>, generated_at: &str) -> Option<f64> {
+    let generated = DateTime::parse_from_rfc3339(generated_at).ok()?;
+    let delay = (*now - generated.with_timezone(&Utc)).num_milliseconds() as f64 / 1000.0;
+    Some(delay.max(0.0))
 }
 
 /// Per-call jitter in `[0, 1s)` nanoseconds, derived from the address of a

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -38,6 +38,7 @@
 //! not turn into an I/O storm.
 
 use arc_swap::ArcSwap;
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
@@ -632,6 +633,11 @@ impl Default for SchemaRegistry {
 ///
 /// Replaces the polling watcher thread: idle processes do no work, and
 /// concurrent readers coordinate through the timestamp CAS.
+/// Callback invoked when a namespace's values are updated.
+/// Arguments: `(namespace, delay_secs)` where `delay_secs` is the propagation
+/// delay from ConfigMap generation to the app reading the new values.
+pub type PropagationCallback = Box<dyn Fn(&str, f64) + Send + Sync>;
+
 pub struct ValuesStore {
     registry: Arc<SchemaRegistry>,
     values_dir: PathBuf,
@@ -639,12 +645,27 @@ pub struct ValuesStore {
     baseline: Instant,
     last_refresh_offset_ns: AtomicU64,
     refresh_threshold: Duration,
+    /// Last known `generated_at` per namespace, used to detect value changes.
+    /// Uses ArcSwap for lock-free, fork-safe access.
+    last_generated_at: ArcSwap<HashMap<String, String>>,
+    /// Optional callback invoked when propagation delay is measured.
+    on_propagation: Option<PropagationCallback>,
 }
 
 impl ValuesStore {
     /// Build a store and perform the initial values load synchronously.
     pub fn new(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValidationResult<Self> {
         Self::with_threshold(registry, values_dir, REFRESH_THRESHOLD)
+    }
+
+    /// Build a store with a callback that fires whenever new values are detected.
+    /// The callback receives `(namespace, delay_secs)` on each value change.
+    pub fn with_propagation_callback(
+        registry: Arc<SchemaRegistry>,
+        values_dir: &Path,
+        callback: PropagationCallback,
+    ) -> ValidationResult<Self> {
+        Self::build(registry, values_dir, REFRESH_THRESHOLD, Some(callback))
     }
 
     /// Test-only constructor that lets the caller pick the refresh threshold.
@@ -654,12 +675,21 @@ impl ValuesStore {
         values_dir: &Path,
         refresh_threshold: Duration,
     ) -> ValidationResult<Self> {
+        Self::build(registry, values_dir, refresh_threshold, None)
+    }
+
+    fn build(
+        registry: Arc<SchemaRegistry>,
+        values_dir: &Path,
+        refresh_threshold: Duration,
+        on_propagation: Option<PropagationCallback>,
+    ) -> ValidationResult<Self> {
         if !should_suppress_missing_dir_errors() && fs::metadata(values_dir).is_err() {
             eprintln!("Values directory does not exist: {}", values_dir.display());
         }
 
         let baseline = Instant::now();
-        let (initial, _) = registry.load_values_json(values_dir)?;
+        let (initial, generated_at_by_namespace) = registry.load_values_json(values_dir)?;
         let last_refresh_offset_ns = AtomicU64::new(baseline.elapsed().as_nanos() as u64);
 
         Ok(Self {
@@ -669,6 +699,8 @@ impl ValuesStore {
             baseline,
             last_refresh_offset_ns,
             refresh_threshold,
+            last_generated_at: ArcSwap::from_pointee(generated_at_by_namespace),
+            on_propagation,
         })
     }
 
@@ -715,8 +747,9 @@ impl ValuesStore {
         // but the ArcSwap still holds the previous snapshot on weakly ordered
         // architectures.
         match result {
-            Ok((new_values, _)) => {
+            Ok((new_values, new_generated_at)) => {
                 self.values.store(Arc::new(new_values));
+                self.emit_propagation_events(new_generated_at);
             }
             Err(e) => {
                 eprintln!(
@@ -738,6 +771,40 @@ impl ValuesStore {
             Ordering::Relaxed,
         );
     }
+
+    /// Compare new `generated_at` timestamps against the last known ones.
+    /// For each namespace where the timestamp changed, invoke the callback
+    /// with the propagation delay. Uses ArcSwap for fork-safe, lock-free access.
+    fn emit_propagation_events(&self, new_generated_at: HashMap<String, String>) {
+        let callback = match &self.on_propagation {
+            Some(cb) => cb,
+            None => {
+                // Still update the stored timestamps so a callback added later
+                // doesn't see stale state.
+                self.last_generated_at.store(Arc::new(new_generated_at));
+                return;
+            }
+        };
+
+        let applied_at = Utc::now();
+        let last = self.last_generated_at.load();
+
+        for (namespace, new_ts) in &new_generated_at {
+            let changed = last.get(namespace).is_none_or(|old_ts| old_ts != new_ts);
+            if !changed {
+                continue;
+            }
+
+            if let Ok(generated_time) = DateTime::parse_from_rfc3339(new_ts) {
+                let delay_secs = (applied_at - generated_time.with_timezone(&Utc))
+                    .num_milliseconds() as f64
+                    / 1000.0;
+                callback(namespace, delay_secs.max(0.0));
+            }
+        }
+
+        self.last_generated_at.store(Arc::new(new_generated_at));
+    }
 }
 
 /// Per-call jitter in `[0, 1s)` nanoseconds, derived from the address of a
@@ -753,6 +820,7 @@ fn stack_jitter_ns() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
 
     fn create_test_schema(temp_dir: &TempDir, namespace: &str, schema_json: &str) -> PathBuf {
@@ -1510,6 +1578,104 @@ Error: \"version\" is a required property"
             generated_at_by_namespace.get("test"),
             Some(&"2024-01-21T18:30:00.123456+00:00".to_string())
         );
+    }
+
+    #[test]
+    fn test_propagation_event_emitted_on_generated_at_change() {
+        let temp_dir = TempDir::new().unwrap();
+        let schemas_dir = temp_dir.path().join("schemas");
+        let values_dir = temp_dir.path().join("values");
+
+        let schema_dir = schemas_dir.join("test");
+        fs::create_dir_all(&schema_dir).unwrap();
+        fs::write(
+            schema_dir.join("schema.json"),
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "enabled": {"type": "boolean", "default": false, "description": "Enabled"}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let test_values_dir = values_dir.join("test");
+        fs::create_dir_all(&test_values_dir).unwrap();
+        fs::write(
+            test_values_dir.join("values.json"),
+            r#"{"options": {"enabled": true}, "generated_at": "2024-01-21T18:30:00+00:00"}"#,
+        )
+        .unwrap();
+
+        let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+
+        let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+        let store = ValuesStore::build(
+            registry,
+            &values_dir,
+            Duration::ZERO,
+            Some(Box::new(move |ns, delay| {
+                events_clone.lock().unwrap().push((ns.to_string(), delay));
+            })),
+        )
+        .unwrap();
+
+        // Initial load doesn't emit (generated_at set during construction).
+        assert!(events.lock().unwrap().is_empty());
+
+        // Same generated_at — no event on reload.
+        let _ = store.load();
+        assert!(events.lock().unwrap().is_empty());
+
+        // Update the generated_at timestamp — should emit on next load.
+        fs::write(
+            test_values_dir.join("values.json"),
+            r#"{"options": {"enabled": true}, "generated_at": "2024-01-21T19:00:00+00:00"}"#,
+        )
+        .unwrap();
+
+        let _ = store.load();
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].0, "test");
+        assert!(captured[0].1 > 0.0);
+    }
+
+    #[test]
+    fn test_propagation_event_not_emitted_without_callback() {
+        let temp_dir = TempDir::new().unwrap();
+        let schemas_dir = temp_dir.path().join("schemas");
+        let values_dir = temp_dir.path().join("values");
+
+        let schema_dir = schemas_dir.join("test");
+        fs::create_dir_all(&schema_dir).unwrap();
+        fs::write(
+            schema_dir.join("schema.json"),
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "enabled": {"type": "boolean", "default": false, "description": "Enabled"}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let test_values_dir = values_dir.join("test");
+        fs::create_dir_all(&test_values_dir).unwrap();
+        fs::write(
+            test_values_dir.join("values.json"),
+            r#"{"options": {"enabled": true}, "generated_at": "2024-01-21T18:30:00+00:00"}"#,
+        )
+        .unwrap();
+
+        let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+        // No callback — should not panic or error.
+        let store = ValuesStore::with_threshold(registry, &values_dir, Duration::ZERO).unwrap();
+        let _ = store.load();
+        // Just verify it doesn't crash.
     }
 
     #[test]

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -1674,6 +1674,147 @@ Error: \"version\" is a required property"
         // Just verify it doesn't crash.
     }
 
+    /// Write a boolean-only schema and a values file for `namespace` under
+    /// `base`, returning the path of the written `values.json`.
+    fn write_ns(base: &Path, namespace: &str, generated_at: &str) -> PathBuf {
+        let schema_dir = base.join("schemas").join(namespace);
+        fs::create_dir_all(&schema_dir).unwrap();
+        fs::write(
+            schema_dir.join("schema.json"),
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "enabled": {"type": "boolean", "default": false, "description": "Enabled"}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let ns_values_dir = base.join("values").join(namespace);
+        fs::create_dir_all(&ns_values_dir).unwrap();
+        let values_file = ns_values_dir.join("values.json");
+        fs::write(
+            &values_file,
+            format!(
+                r#"{{"options": {{"enabled": true}}, "generated_at": "{generated_at}"}}"#
+            ),
+        )
+        .unwrap();
+        values_file
+    }
+
+    #[test]
+    fn test_propagation_delay_secs_parsing() {
+        let now: DateTime<Utc> = "2024-01-21T19:00:00+00:00".parse().unwrap();
+
+        // Normal case: 30 minutes elapsed.
+        assert_eq!(
+            propagation_delay_secs(&now, "2024-01-21T18:30:00+00:00"),
+            Some(1800.0)
+        );
+        // Clock skew (generated_at in the future) clamps to 0 rather than going negative.
+        assert_eq!(
+            propagation_delay_secs(&now, "2024-01-21T19:05:00+00:00"),
+            Some(0.0)
+        );
+        // Malformed timestamp returns None.
+        assert_eq!(propagation_delay_secs(&now, "not-a-timestamp"), None);
+    }
+
+    #[test]
+    fn test_propagation_callback_panic_is_caught() {
+        let temp_dir = TempDir::new().unwrap();
+        let base = temp_dir.path();
+        let values_file = write_ns(base, "test", "2024-01-21T18:30:00+00:00");
+
+        let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
+        let store = ValuesStore::build(
+            registry,
+            &base.join("values"),
+            Duration::ZERO,
+            Some(Box::new(|_ns, _delay| panic!("callback boom"))),
+        )
+        .unwrap();
+
+        // Trigger a change so the panicking callback fires; load() must not unwind.
+        fs::write(
+            &values_file,
+            r#"{"options": {"enabled": false}, "generated_at": "2024-01-21T19:00:00+00:00"}"#,
+        )
+        .unwrap();
+        let _ = store.load();
+
+        // The values refresh still applied despite the callback panic.
+        assert_eq!(
+            store.values.load().get("test").unwrap().get("enabled"),
+            Some(&json!(false))
+        );
+    }
+
+    #[test]
+    fn test_propagation_malformed_generated_at_does_not_emit() {
+        let temp_dir = TempDir::new().unwrap();
+        let base = temp_dir.path();
+        let values_file = write_ns(base, "test", "2024-01-21T18:30:00+00:00");
+
+        let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
+        let store = ValuesStore::build(
+            registry,
+            &base.join("values"),
+            Duration::ZERO,
+            Some(Box::new(move |ns, delay| {
+                events_clone.lock().unwrap().push((ns.to_string(), delay));
+            })),
+        )
+        .unwrap();
+
+        // Change generated_at to a malformed value: detected as a change, but
+        // unparseable, so no event is emitted.
+        fs::write(
+            &values_file,
+            r#"{"options": {"enabled": true}, "generated_at": "garbage"}"#,
+        )
+        .unwrap();
+        let _ = store.load();
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_propagation_only_changed_namespace_emits() {
+        let temp_dir = TempDir::new().unwrap();
+        let base = temp_dir.path();
+        write_ns(base, "alpha", "2024-01-21T18:00:00+00:00");
+        let beta_values = write_ns(base, "beta", "2024-01-21T18:00:00+00:00");
+
+        let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = events.clone();
+        let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
+        let store = ValuesStore::build(
+            registry,
+            &base.join("values"),
+            Duration::ZERO,
+            Some(Box::new(move |ns, delay| {
+                events_clone.lock().unwrap().push((ns.to_string(), delay));
+            })),
+        )
+        .unwrap();
+
+        // Only beta's generated_at changes; alpha is untouched.
+        fs::write(
+            &beta_values,
+            r#"{"options": {"enabled": true}, "generated_at": "2024-01-21T19:00:00+00:00"}"#,
+        )
+        .unwrap();
+        let _ = store.load();
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].0, "beta");
+    }
+
     #[test]
     fn test_load_values_json_rejects_wrong_type() {
         let temp_dir = TempDir::new().unwrap();

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -655,7 +655,7 @@ pub struct ValuesStore {
 impl ValuesStore {
     /// Build a store and perform the initial values load synchronously.
     pub fn new(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValidationResult<Self> {
-        Self::with_threshold(registry, values_dir, REFRESH_THRESHOLD)
+        Self::build(registry, values_dir, REFRESH_THRESHOLD, None)
     }
 
     /// Build a store with a callback that fires whenever new values are detected.
@@ -668,16 +668,8 @@ impl ValuesStore {
         Self::build(registry, values_dir, REFRESH_THRESHOLD, Some(callback))
     }
 
-    /// Test-only constructor that lets the caller pick the refresh threshold.
-    /// `Duration::ZERO` makes every `load()` perform a refresh attempt.
-    pub(crate) fn with_threshold(
-        registry: Arc<SchemaRegistry>,
-        values_dir: &Path,
-        refresh_threshold: Duration,
-    ) -> ValidationResult<Self> {
-        Self::build(registry, values_dir, refresh_threshold, None)
-    }
-
+    /// Internal constructor. `Duration::ZERO` threshold makes every `load()`
+    /// refresh, which is useful for tests.
     fn build(
         registry: Arc<SchemaRegistry>,
         values_dir: &Path,
@@ -782,7 +774,7 @@ impl ValuesStore {
 
     /// Invoke the propagation callback for each namespace whose `generated_at`
     /// changed since the last refresh. Skips entirely when no callback is
-    /// registered or when nothing changed (avoids an Arc allocation every cycle).
+    /// registered or when nothing changed.
     fn emit_propagation_events(&self, new_generated_at: HashMap<String, String>) {
         let last = self.last_generated_at.load();
         if *last.as_ref() == new_generated_at {
@@ -1684,7 +1676,7 @@ Error: \"version\" is a required property"
 
         let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
         // No callback — should not panic or error.
-        let store = ValuesStore::with_threshold(registry, &values_dir, Duration::ZERO).unwrap();
+        let store = ValuesStore::build(registry, &values_dir, Duration::ZERO, None).unwrap();
         let _ = store.load();
         // Just verify it doesn't crash.
     }
@@ -2052,7 +2044,7 @@ Error: \"version\" is a required property"
 
         fn store_with_zero_threshold(schemas_dir: &Path, values_dir: &Path) -> ValuesStore {
             let registry = Arc::new(SchemaRegistry::from_directory(schemas_dir).unwrap());
-            ValuesStore::with_threshold(registry, values_dir, Duration::ZERO).unwrap()
+            ValuesStore::build(registry, values_dir, Duration::ZERO, None).unwrap()
         }
 
         #[test]


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/DI-1959/built-in-metrics

The purpose of this PR is to expose the `propagation_time` metric without using Sentry (which was removed in a previous PR).  Propagation time is defined as the time from when the ConfigMap was generated, until it being read in production. 

To accomplish this, we store the last `generated_at` timestamp and compare it on every refresh. If it changes, our configmap has updated and we can emit a new `propagation_time`. Because every client will have a different metrics implementation, instead of emitting the metrics ourselves, we allow clients to pass in a callback (rust or python). We pass in the namespace and propagation time into this callback and it can decide what to do with it (if anything at all).

We need to take advantage of some tricky `Box` and `ArcSwap` stuff to makes sure its all thread-safe without locks but otherwise the high-level logic itself is fairly straightforward.