### PR TITLE
fix(cli): Strip unknown keys on the validation

### DIFF
--- a/sentry-options-cli/src/loader.rs
+++ b/sentry-options-cli/src/loader.rs
@@ -167,6 +167,7 @@ fn validate_and_parse(
     }
 
     let values_json = serde_json::to_value(&result)?;
+    let values_json = schema_registry.strip_unknown_keys(namespace, &values_json);
     schema_registry
         .validate_values(namespace, &values_json)
         .map_err(|e| AppError::Validation(format!("In file {}: {}", path, e)))?;

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -580,7 +580,7 @@ impl SchemaRegistry {
 
     /// Remove keys from values that are not defined in the namespace schema.
     /// Logs a warning for each removed key. Returns the filtered values object.
-    fn strip_unknown_keys(&self, namespace: &str, values: &Value) -> Value {
+    pub fn strip_unknown_keys(&self, namespace: &str, values: &Value) -> Value {
         let schema = match self.schemas.get(namespace) {
             Some(s) => s,
             None => return values.clone(),


### PR DESCRIPTION
Because we lifted the deletion protection, we should also allow validators to accept unknown keys. We just strip them and `eprintln`. 

**Importantly**, we are still going to deploy unknown option values to avoid race conditions with the decoupled deployments. e.g.:

1. A PR in getsentry goes out removing a `option.get("enabled")` and registration `enabled: default false`
2. A PR in options-automator then goes out deleting the value of enabled, `- enabled: true`
Because the automator change will go out faster than the getsentry change, all regions where code change hasn't been deployed yet will all of a sudden see `enabled:false`.

Deploying all option values whether or not they are registered circumvents this problem.