### PR TITLE
feat(validation): allow nested value types in option schemas

### DIFF
--- a/sentry-options-gen-stubs/__init__.py
+++ b/sentry-options-gen-stubs/__init__.py
@@ -39,72 +39,67 @@ def namespace_to_class(namespace: str) -> str:
     return 'NamespaceOptions_' + _ident(namespace)
 
 
-def _field_type(parent_key: str, field: str, prop: dict) -> str:
-    """Resolve a primitive field type inside an object/array-of-objects.
+def _resolve_type(
+    prop: dict,
+    class_name: str,
+    key: str,
+    typed_dicts: dict[str, list[tuple[str, str]]],
+    counter: list[int],
+    suffix: str = 'Dict',
+) -> str:
+    """Resolve a value-type schema to a Python type string, recursively.
 
-    If the field has "optional": true, wraps the type in NotRequired[...].
+    Scalars map to str/int/float/bool. Arrays resolve to list[T]. Maps
+    (objects with `additionalProperties` and no `properties`) resolve to
+    dict[str, V]. Fixed-shape objects (with `properties`) generate a TypedDict
+    collected into typed_dicts. Value types nest arbitrarily, so every
+    container recurses into its element/value schema.
+
+    TypedDicts use index-based names to avoid collisions and the functional
+    form to preserve original key names (e.g. hyphens). `suffix` names the
+    generated TypedDict: array items use `_Item`, every other object `_Dict`.
     """
     t = prop.get('type', '')
-    if t not in _SCHEMA_TO_PYTHON:
+    if t in _SCHEMA_TO_PYTHON:
+        return _SCHEMA_TO_PYTHON[t]
+    if t == 'array':
+        items = prop.get('items')
+        if not items:
+            raise ValueError(f'{key!r}: array has no items')
+        inner = _resolve_type(items, class_name, key, typed_dicts, counter, 'Item')
+        return f'list[{inner}]'
+    if t == 'object':
+        obj_props = prop.get('properties')
+        if obj_props:
+            td = f'_{class_name}_{counter[0]}_{suffix}'
+            counter[0] += 1
+            typed_dicts[td] = [
+                (k, _field_type(v, class_name, f'{key}.{k}', typed_dicts, counter))
+                for k, v in obj_props.items()
+            ]
+            return td
+        value_type = prop.get('additionalProperties')
+        if isinstance(value_type, dict):
+            inner = _resolve_type(value_type, class_name, key, typed_dicts, counter)
+            return f'dict[str, {inner}]'
         raise ValueError(
-            f'{parent_key!r}: field {field!r} has unknown type {t!r}',
+            f'{key!r}: object has neither properties nor additionalProperties',
         )
-    py_type = _SCHEMA_TO_PYTHON[t]
-    if prop.get('optional'):
-        return f'NotRequired[{py_type}]'
-    return py_type
+    raise ValueError(f'{key!r}: unknown type {t!r}')
 
 
-def _prop_to_type(
+def _field_type(
     prop: dict,
     class_name: str,
     key: str,
     typed_dicts: dict[str, list[tuple[str, str]]],
     counter: list[int],
 ) -> str:
-    """
-    Resolve a schema property to a Python type string.
-
-    Typed arrays (items.type) resolve to list[T].
-    Objects and array-of-objects with properties generate TypedDicts
-    collected into typed_dicts, keyed by their generated class name.
-    TypedDicts use index-based names to avoid collisions, and the
-    functional form to preserve original key names (e.g. hyphens).
-    """
-    t = prop.get('type', '')
-    if t in _SCHEMA_TO_PYTHON:
-        return _SCHEMA_TO_PYTHON[t]
-    if t == 'array':
-        items = prop.get('items', {})
-        item_t = items.get('type', '')
-        if item_t in _SCHEMA_TO_PYTHON:
-            return f'list[{_SCHEMA_TO_PYTHON[item_t]}]'
-        if item_t == 'object':
-            item_props = items.get('properties', {})
-            if not item_props:
-                raise ValueError(
-                    f'{key!r}: array[object] items has no properties',
-                )
-            td = f'_{class_name}_{counter[0]}_Item'
-            counter[0] += 1
-            typed_dicts[td] = [
-                (k, _field_type(key, k, v))
-                for k, v in item_props.items()
-            ]
-            return f'list[{td}]'
-        raise ValueError(f'{key!r}: unknown array item type {item_t!r}')
-    if t == 'object':
-        obj_props = prop.get('properties', {})
-        if not obj_props:
-            raise ValueError(f'{key!r}: object has no properties')
-        td = f'_{class_name}_{counter[0]}_Dict'
-        counter[0] += 1
-        typed_dicts[td] = [
-            (k, _field_type(key, k, v))
-            for k, v in obj_props.items()
-        ]
-        return td
-    raise ValueError(f'{key!r}: unknown type {t!r}')
+    """Resolve a TypedDict field type, wrapping optional fields in NotRequired."""
+    inner = _resolve_type(prop, class_name, key, typed_dicts, counter)
+    if prop.get('optional'):
+        return f'NotRequired[{inner}]'
+    return inner
 
 
 def generate(schemas_dir: Path) -> str:
@@ -138,7 +133,7 @@ def generate(schemas_dir: Path) -> str:
         try:
             counter = [0]
             key_types = {
-                key: _prop_to_type(prop, class_name, key, typed_dicts, counter)
+                key: _resolve_type(prop, class_name, key, typed_dicts, counter)
                 for key, prop in props.items()
                 if '$ref' not in prop
             }

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -383,7 +383,14 @@ impl SchemaRegistry {
     ///     "description": "..."
     /// }
     fn inject_object_constraints(schema: &mut Value) {
-        if let Some(obj) = schema.as_object_mut() {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        if obj.get("type").and_then(|t| t.as_str()) == Some("object") {
+            // Fixed-shape object: require every non-optional field. A dynamic map
+            // instead declares `additionalProperties` (a value schema) up front, so
+            // only inject `required` when there are declared `properties`.
             if let Some(props) = obj.get("properties").and_then(|p| p.as_object()) {
                 let required: Vec<Value> = props
                     .iter()
@@ -392,9 +399,27 @@ impl SchemaRegistry {
                     .collect();
                 obj.insert("required".to_string(), Value::Array(required));
             }
+            // Reject unknown keys unless the schema already declares an
+            // `additionalProperties` value type (i.e. it is a dynamic map).
             if !obj.contains_key("additionalProperties") {
                 obj.insert("additionalProperties".to_string(), json!(false));
             }
+        }
+
+        // Recurse so the same constraints apply at every level of a nested value
+        // schema: object-valued maps, arrays of objects, and nested fixed shapes.
+        if let Some(props) = obj.get_mut("properties").and_then(|p| p.as_object_mut()) {
+            for field in props.values_mut() {
+                Self::inject_object_constraints(field);
+            }
+        }
+        if let Some(additional) = obj.get_mut("additionalProperties")
+            && additional.is_object()
+        {
+            Self::inject_object_constraints(additional);
+        }
+        if let Some(items) = obj.get_mut("items") {
+            Self::inject_object_constraints(items);
         }
     }
 
@@ -409,25 +434,11 @@ impl SchemaRegistry {
             obj.insert("additionalProperties".to_string(), json!(false));
         }
 
-        // Inject object constraints (required + additionalProperties) for object-typed options
-        // so that jsonschema validates the full shape of object values.
+        // Inject object constraints (required + additionalProperties) at every level
+        // of each option's value schema so jsonschema validates the full shape.
         if let Some(properties) = schema.get_mut("properties").and_then(|p| p.as_object_mut()) {
             for prop_value in properties.values_mut() {
-                let prop_type = prop_value
-                    .get("type")
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("");
-
-                if prop_type == "object" {
-                    Self::inject_object_constraints(prop_value);
-                } else if prop_type == "array"
-                    && let Some(items) = prop_value.get_mut("items")
-                {
-                    let items_type = items.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                    if items_type == "object" {
-                        Self::inject_object_constraints(items);
-                    }
-                }
+                Self::inject_object_constraints(prop_value);
             }
         }
 
@@ -3266,5 +3277,283 @@ Error: \"version\" is a required property"
             let result = registry.load_values_json(&values_dir);
             assert!(result.is_ok());
         }
+    }
+
+    #[test]
+    fn test_object_valued_map_validates_nested_values() {
+        // {orgId: {max_candidates: int}} — a map whose values are objects, previously
+        // inexpressible because map values were scalar-only.
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "org_tweaks": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {"type": "integer"}
+                        },
+                        "default": {},
+                        "description": ""
+                    }
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        assert!(
+            registry
+                .validate_values(
+                    "test",
+                    &json!({"org_tweaks": {"1": {"max_candidates": 20}}})
+                )
+                .is_ok()
+        );
+        assert!(
+            registry
+                .validate_values("test", &json!({"org_tweaks": {}}))
+                .is_ok()
+        );
+        // inner value of the wrong type
+        assert!(matches!(
+            registry.validate_values(
+                "test",
+                &json!({"org_tweaks": {"1": {"max_candidates": "x"}}})
+            ),
+            Err(ValidationError::ValueError { .. })
+        ));
+        // map value is not an object
+        assert!(matches!(
+            registry.validate_values("test", &json!({"org_tweaks": {"1": 20}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_valued_map_validates_nested_values() {
+        // {key: [string]} — a map whose values are arrays.
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "webhook_logging": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "default": {},
+                        "description": ""
+                    }
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        assert!(
+            registry
+                .validate_values(
+                    "test",
+                    &json!({"webhook_logging": {"a": [], "b": ["x", "y"]}})
+                )
+                .is_ok()
+        );
+        // array element of the wrong type
+        assert!(matches!(
+            registry.validate_values("test", &json!({"webhook_logging": {"a": [1]}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+        // map value is not an array
+        assert!(matches!(
+            registry.validate_values("test", &json!({"webhook_logging": {"a": "x"}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_nested_fixed_object_enforces_required_and_rejects_unknown() {
+        // Map value is a fixed-shape object: `required` and `additionalProperties: false`
+        // must be injected at depth, not only at the top level.
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "quotas": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "limit": {"type": "integer"},
+                                "window": {"type": "integer"}
+                            }
+                        },
+                        "default": {},
+                        "description": ""
+                    }
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        assert!(
+            registry
+                .validate_values("test", &json!({"quotas": {"o": {"limit": 1, "window": 2}}}))
+                .is_ok()
+        );
+        // missing a required nested field
+        assert!(matches!(
+            registry.validate_values("test", &json!({"quotas": {"o": {"limit": 1}}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+        // unknown nested field rejected (additionalProperties: false injected at depth)
+        assert!(matches!(
+            registry.validate_values(
+                "test",
+                &json!({"quotas": {"o": {"limit": 1, "window": 2, "x": 3}}})
+            ),
+            Err(ValidationError::ValueError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_optional_marker_works_at_depth() {
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "items_map": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "weight": {"type": "integer", "optional": true}
+                            }
+                        },
+                        "default": {},
+                        "description": ""
+                    }
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        // optional field omitted -> ok
+        assert!(
+            registry
+                .validate_values("test", &json!({"items_map": {"a": {"url": "x"}}}))
+                .is_ok()
+        );
+        // required field omitted -> fail
+        assert!(matches!(
+            registry.validate_values("test", &json!({"items_map": {"a": {"weight": 1}}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_three_levels_of_nesting() {
+        // object -> array -> object -> scalar map
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "deep": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": {"type": "integer"}
+                            }
+                        },
+                        "default": {},
+                        "description": ""
+                    }
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        assert!(
+            registry
+                .validate_values("test", &json!({"deep": {"a": [{"x": 1}, {"y": 2}]}}))
+                .is_ok()
+        );
+        assert!(matches!(
+            registry.validate_values("test", &json!({"deep": {"a": [{"x": "no"}]}})),
+            Err(ValidationError::ValueError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_meta_schema_rejects_malformed_nested_value_types() {
+        // object value with neither `properties` nor `additionalProperties`
+        assert!(matches!(
+            SchemaRegistry::from_schemas(&[(
+                "test",
+                r#"{"version":"1.0","type":"object","properties":{
+                    "m":{"type":"object","additionalProperties":{"type":"object"},"default":{},"description":""}}}"#,
+            )]),
+            Err(ValidationError::SchemaError { .. })
+        ));
+        // array value without `items`
+        assert!(matches!(
+            SchemaRegistry::from_schemas(&[(
+                "test",
+                r#"{"version":"1.0","type":"object","properties":{
+                    "m":{"type":"object","additionalProperties":{"type":"array"},"default":{},"description":""}}}"#,
+            )]),
+            Err(ValidationError::SchemaError { .. })
+        ));
+        // unknown keyword inside a nested value type
+        assert!(matches!(
+            SchemaRegistry::from_schemas(&[(
+                "test",
+                r#"{"version":"1.0","type":"object","properties":{
+                    "m":{"type":"object","additionalProperties":{"type":"string","bogus":1},"default":{},"description":""}}}"#,
+            )]),
+            Err(ValidationError::SchemaError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_pre_existing_shapes_still_validate() {
+        // Scalar map and fixed-shape object (the only shapes allowed before) keep working.
+        let registry = SchemaRegistry::from_schemas(&[(
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "scopes": {"type": "object", "additionalProperties": {"type": "string"}, "default": {}, "description": ""},
+                    "config": {"type": "object", "properties": {"host": {"type": "string"}}, "default": {"host": "h"}, "description": ""}
+                }
+            }"#,
+        )])
+        .unwrap();
+
+        assert!(
+            registry
+                .validate_values(
+                    "test",
+                    &json!({"scopes": {"r": "1"}, "config": {"host": "x"}})
+                )
+                .is_ok()
+        );
+        assert!(matches!(
+            registry.validate_values("test", &json!({"config": {"host": "x", "extra": "y"}})),
+            Err(ValidationError::ValueError { .. })
+        ));
     }
 }

--- a/sentry-options-validation/src/namespace-schema.json
+++ b/sentry-options-validation/src/namespace-schema.json
@@ -35,44 +35,14 @@
             "description": {
               "type": "string"
             },
-            "additionalProperties": {
-              "$ref": "#/$defs/map_value_type"
-            },
             "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "enum": ["string", "integer", "number", "boolean", "object"]
-                },
-                "properties": {
-                  "$ref": "#/$defs/shape"
-                },
-                "additionalProperties": {
-                  "$ref": "#/$defs/map_value_type"
-                }
-              },
-              "required": ["type"],
-              "additionalProperties": false,
-              "allOf": [
-                {
-                  "if": {
-                    "properties": {
-                      "type": {
-                        "const": "object"
-                      }
-                    },
-                    "not": {
-                      "required": ["additionalProperties"]
-                    }
-                  },
-                  "then": {
-                    "required": ["properties"]
-                  }
-                }
-              ]
+              "$ref": "#/$defs/value_type"
+            },
+            "additionalProperties": {
+              "$ref": "#/$defs/value_type"
             },
             "properties": {
-              "$ref": "#/$defs/shape"
+              "$ref": "#/$defs/value_shape"
             }
           },
           "required": ["type", "default", "description"],
@@ -114,48 +84,62 @@
   "required": ["version", "type", "properties"],
   "additionalProperties": false,
   "$defs": {
-    "map_value_type": {
+    "value_type": {
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["string", "integer", "number", "boolean"]
+          "enum": ["string", "integer", "number", "boolean", "array", "object"]
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "items": {
+          "$ref": "#/$defs/value_type"
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/value_type"
+        },
+        "properties": {
+          "$ref": "#/$defs/value_shape"
         }
       },
       "required": ["type"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "array"
+              }
+            }
+          },
+          "then": {
+            "required": ["items"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "object"
+              }
+            },
+            "not": {
+              "required": ["additionalProperties"]
+            }
+          },
+          "then": {
+            "required": ["properties"]
+          }
+        }
+      ]
     },
-    "shape": {
+    "value_shape": {
       "type": "object",
       "patternProperties": {
         ".*": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": ["string", "integer", "number", "boolean", "object"]
-            },
-            "optional": {
-              "type": "boolean"
-            },
-            "additionalProperties": {
-              "$ref": "#/$defs/map_value_type"
-            }
-          },
-          "required": ["type"],
-          "additionalProperties": false,
-          "allOf": [
-            {
-              "if": {
-                "properties": {
-                  "type": {
-                    "const": "object"
-                  }
-                }
-              },
-              "then": {
-                "required": ["additionalProperties"]
-              }
-            }
-          ]
+          "$ref": "#/$defs/value_type"
         }
       },
       "additionalProperties": false

--- a/tests/gen_stubs_test.py
+++ b/tests/gen_stubs_test.py
@@ -274,3 +274,103 @@ def test_generate_empty_namespace_no_overload(tmp_path: Path) -> None:
 
 def test_generate_is_deterministic(schemas_dir: Path) -> None:
     assert generate(schemas_dir) == generate(schemas_dir)
+
+
+def _single_key_schema(tmp_path: Path, prop: dict) -> Path:
+    ns_dir = tmp_path / 'svc'
+    ns_dir.mkdir()
+    (ns_dir / 'schema.json').write_text(
+        json.dumps({
+            'version': '1.0',
+            'type': 'object',
+            'properties': {'k': {**prop, 'default': None}},
+        }),
+    )
+    return tmp_path
+
+
+def test_generate_scalar_map(tmp_path: Path) -> None:
+    output = generate(
+        _single_key_schema(
+            tmp_path, {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+            },
+        ),
+    )
+    assert 'def get(self, key: Literal["k"]) -> dict[str, str]' in output
+
+
+def test_generate_array_valued_map(tmp_path: Path) -> None:
+    # {key: [string]} — sentry-apps.webhook-logging.enabled
+    output = generate(
+        _single_key_schema(
+            tmp_path, {
+                'type': 'object',
+                'additionalProperties': {'type': 'array', 'items': {'type': 'string'}},
+            },
+        ),
+    )
+    assert 'def get(self, key: Literal["k"]) -> dict[str, list[str]]' in output
+
+
+def test_generate_object_valued_map(tmp_path: Path) -> None:
+    # {orgId: {max_candidates: int}} — seer.night_shift.org_tweaks
+    output = generate(
+        _single_key_schema(
+            tmp_path, {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'additionalProperties': {'type': 'integer'},
+                },
+            },
+        ),
+    )
+    assert (
+        'def get(self, key: Literal["k"]) -> dict[str, dict[str, int]]'
+        in output
+    )
+
+
+def test_generate_map_of_typed_objects(tmp_path: Path) -> None:
+    output = generate(
+        _single_key_schema(
+            tmp_path, {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'object',
+                    'properties': {
+                        'limit': {'type': 'integer'},
+                        'window': {'type': 'integer', 'optional': True},
+                    },
+                },
+            },
+        ),
+    )
+    td = '_NamespaceOptions_svc_0_Dict'
+    assert f"{td} = TypedDict('{td}'" in output
+    assert "    'limit': int," in output
+    assert "    'window': NotRequired[int]," in output
+    assert f'def get(self, key: Literal["k"]) -> dict[str, {td}]' in output
+
+
+def test_generate_nested_map_field_in_fixed_object(tmp_path: Path) -> None:
+    output = generate(
+        _single_key_schema(
+            tmp_path, {
+                'type': 'object',
+                'properties': {
+                    'scopes': {'type': 'object', 'additionalProperties': {'type': 'string'}},
+                },
+            },
+        ),
+    )
+    assert "    'scopes': dict[str, str]," in output
+
+
+def test_object_with_neither_properties_nor_additional_raises(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(SystemExit):
+        generate(_single_key_schema(tmp_path, {'type': 'object'}))


### PR DESCRIPTION
these 2 options are not expressible in new options:

```json
// seer.night_shift.org_tweaks  -> {orgId: {max_candidates: int}}
{ "type": "object",
  "additionalProperties": { "type": "object", "additionalProperties": { "type": "integer" } } }

// sentry-apps.webhook-logging.enabled  -> {key: [string]}
{ "type": "object",
  "additionalProperties": { "type": "array", "items": { "type": "string" } } }
```

first got rejected because a map value can't be an object, second because it can't be an array

the meta-schema only let a map value (`additionalProperties`) or array `items` be a scalar, so any option whose value nests was inexpressible

---

fix: made the value type recursive — replaced the scalar-only `map_value_type`/`shape` defs with one `value_type` referenced from `additionalProperties`, `items`, and object fields, so values can nest arbitrarily. `inject_object_constraints` recurses too, so `required` + `additionalProperties: false` apply at every object level (else nested fixed-shape objects validate too loosely).

no client/runtime changes — value validation already uses a generic `jsonschema` validator and reads return raw json. `value_type` is a strict superset of the old shapes, so existing schemas still validate.
