### PR TITLE
feat(client): Use builder for rust `init()`

### DIFF
--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -7,7 +7,7 @@ use ::sentry_options::{
     FeatureChecker as RustFeatureChecker, FeatureContext as RustFeatureContext,
     Options as RustOptions, OptionsError as RustOptionsError,
 };
-use pyo3::exceptions::{PyException, PyValueError};
+use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 use serde_json::Value;
@@ -116,6 +116,9 @@ fn options_err(err: RustOptionsError) -> PyErr {
     match err {
         RustOptionsError::NotInitialized => {
             NotInitializedError::new_err("Options not initialized - call init() first")
+        }
+        RustOptionsError::AlreadyInitialized => {
+            PyRuntimeError::new_err("Options already initialized")
         }
         RustOptionsError::UnknownNamespace(ns) => {
             UnknownNamespaceError::new_err(format!("Unknown namespace: {}", ns))

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -154,6 +154,61 @@ impl Options {
     }
 }
 
+#[derive(Default)]
+pub struct InitBuilder<'a> {
+    directory: Option<&'a Path>,
+    schemas: Option<&'a [(&'a str, &'a str)]>,
+    callback: Option<PropagationCallback>,
+}
+
+impl<'a> InitBuilder<'a> {
+    pub fn new() -> Self {
+        InitBuilder::default()
+    }
+
+    pub fn with_directory(mut self, directory: &'a Path) -> Self {
+        self.directory = Some(directory);
+        self
+    }
+
+    pub fn with_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
+        self.schemas = Some(schemas);
+        self
+    }
+
+    pub fn with_callback(mut self, callback: PropagationCallback) -> Self {
+        self.callback = Some(callback);
+        self
+    }
+
+    // If we can get away with not consuming the Builder here, that is an
+    // advantage. It means we can use the FooBuilder as a template for constructing
+    // many Foos.
+    pub fn build(self) -> Result<()> {
+        // don't re-init
+        if GLOBAL_OPTIONS.get().is_some() {
+            return Ok(());
+        }
+
+        // if directory is set, override it.
+        let mut dir = resolve_options_dir();
+        if let Some(d) = self.directory {
+            dir = d.to_path_buf();
+        }
+
+        // if schema is set, use the schema one
+        let mut registry = SchemaRegistry::from_directory(&dir)?;
+        if let Some(s) = self.schemas {
+            registry = SchemaRegistry::from_schemas(s)?;
+        }
+
+        // if callback is set, add it
+        let opts = Options::with_registry_and_values(registry, &dir.join("values"), self.callback)?;
+        let _ = GLOBAL_OPTIONS.set(opts);
+        Ok(())
+    }
+}
+
 /// Initialize global options using fallback chain: `SENTRY_OPTIONS_DIR` env var,
 /// then `/etc/sentry-options` if it exists, otherwise `sentry-options/`.
 ///

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,7 +4,7 @@ pub mod features;
 
 pub use features::{FeatureChecker, FeatureContext, features};
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 pub use sentry_options_validation::PropagationCallback;
@@ -156,7 +156,7 @@ impl Options {
 
 #[derive(Default)]
 pub struct InitBuilder<'a> {
-    directory: Option<&'a Path>,
+    directory: Option<PathBuf>,
     schemas: Option<&'a [(&'a str, &'a str)]>,
     callback: Option<PropagationCallback>,
 }
@@ -166,8 +166,8 @@ impl<'a> InitBuilder<'a> {
         InitBuilder::default()
     }
 
-    pub fn with_directory(mut self, directory: &'a Path) -> Self {
-        self.directory = Some(directory);
+    pub fn with_directory(mut self, directory: impl Into<PathBuf>) -> Self {
+        self.directory = Some(directory.into());
         self
     }
 
@@ -181,28 +181,18 @@ impl<'a> InitBuilder<'a> {
         self
     }
 
-    // If we can get away with not consuming the Builder here, that is an
-    // advantage. It means we can use the FooBuilder as a template for constructing
-    // many Foos.
     pub fn build(self) -> Result<()> {
-        // don't re-init
         if GLOBAL_OPTIONS.get().is_some() {
             return Ok(());
         }
 
-        // if directory is set, override it.
-        let mut dir = resolve_options_dir();
-        if let Some(d) = self.directory {
-            dir = d.to_path_buf();
-        }
+        let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
-        // if schema is set, use the schema one
-        let mut registry = SchemaRegistry::from_directory(&dir)?;
-        if let Some(s) = self.schemas {
-            registry = SchemaRegistry::from_schemas(s)?;
-        }
+        let registry = match self.schemas {
+            Some(s) => SchemaRegistry::from_schemas(s)?,
+            None => SchemaRegistry::from_directory(&dir.join("schemas"))?,
+        };
 
-        // if callback is set, add it
         let opts = Options::with_registry_and_values(registry, &dir.join("values"), self.callback)?;
         let _ = GLOBAL_OPTIONS.set(opts);
         Ok(())

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -154,6 +154,14 @@ impl Options {
     }
 }
 
+/// Builder for initializing the global options store.
+/// Define optional parameters with `with_*` methods, then finalize with `build()`
+///
+/// All settings are optional and independent:
+/// - `with_directory` overrides the base directory
+/// - `with_schemas` supplies schemas in memory instead of reading `{dir}/schemas/`
+/// - `with_callback` registers a callback that fires on every value refresh.
+/// ```
 #[derive(Default)]
 pub struct InitBuilder<'a> {
     directory: Option<PathBuf>,
@@ -166,21 +174,31 @@ impl<'a> InitBuilder<'a> {
         InitBuilder::default()
     }
 
+    /// Override the base directory. Expects `{directory}/schemas/` and `{directory}/values/` subdirectories.
+    /// Otherwise, defaults to the fallback chain: `SENTRY_OPTIONS_DIR` env var, then `/etc/sentry-options`
     pub fn with_directory(mut self, directory: impl Into<PathBuf>) -> Self {
         self.directory = Some(directory.into());
         self
     }
 
+    /// Provide schemas as in-memory `(namespace, json)` pairs instead of reading
+    /// them from `{dir}/schemas/`, intended to be used with `include_str!`
     pub fn with_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
         self.schemas = Some(schemas);
         self
     }
 
+    /// Register a callback that fires `(namespace, delay_secs)` whenever values
+    /// are refreshed with a new `generated_at` timestamp.
     pub fn with_callback(mut self, callback: PropagationCallback) -> Self {
         self.callback = Some(callback);
         self
     }
 
+    /// Initialize the global options store from the inputs.
+    ///
+    /// Idempotent: if options are already initialized, returns `Ok(())` without
+    /// re-loading or applying any of this builder's settings.
     pub fn build(self) -> Result<()> {
         if GLOBAL_OPTIONS.get().is_some() {
             return Ok(());
@@ -203,6 +221,7 @@ impl<'a> InitBuilder<'a> {
 /// then `/etc/sentry-options` if it exists, otherwise `sentry-options/`.
 ///
 /// Idempotent: if already initialized, returns `Ok(())` without re-loading.
+#[deprecated(since = "1.3.0", note = "use `InitBuilder::new().build()`")]
 pub fn init() -> Result<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
@@ -215,6 +234,10 @@ pub fn init() -> Result<()> {
 /// Like [`init`], but with a callback that fires whenever values are refreshed
 /// from disk with a new `generated_at` timestamp. The callback receives
 /// `(namespace, delay_secs)`.
+#[deprecated(
+    since = "1.3.0",
+    note = "use `InitBuilder::new().with_callback(cb).build()`"
+)]
 pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
@@ -236,6 +259,10 @@ pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<(
 ///     ("snuba", include_str!("sentry-options/schemas/snuba/schema.json")),
 /// ])?;
 /// ```
+#[deprecated(
+    since = "1.3.0",
+    note = "use `InitBuilder::new().with_schemas(s).build()`"
+)]
 pub fn init_with_schemas(schemas: &[(&str, &str)]) -> Result<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -207,7 +207,14 @@ impl<'a> InitBuilder<'a> {
         if GLOBAL_OPTIONS.get().is_some() {
             return Err(OptionsError::AlreadyInitialized);
         }
+        GLOBAL_OPTIONS
+            .set(self.build_options()?)
+            .map_err(|_| OptionsError::AlreadyInitialized)
+    }
 
+    /// Helper to return an `Options` with the configured inputs.
+    /// Does not touch the global `OnceLock`.
+    fn build_options(self) -> Result<Options> {
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
         let registry = match self.schemas {
@@ -215,10 +222,7 @@ impl<'a> InitBuilder<'a> {
             None => SchemaRegistry::from_directory(&dir.join("schemas"))?,
         };
 
-        let opts = Options::with_registry_and_values(registry, &dir.join("values"), self.callback)?;
-        GLOBAL_OPTIONS
-            .set(opts)
-            .map_err(|_| OptionsError::AlreadyInitialized)
+        Options::with_registry_and_values(registry, &dir.join("values"), self.callback)
     }
 }
 
@@ -523,5 +527,40 @@ mod tests {
     fn test_from_schemas_invalid_json() {
         let result = SchemaRegistry::from_schemas(&[("test", "not valid json")]);
         assert!(result.is_err());
+    }
+
+    const BOOL_SCHEMA: &str = r#"{
+        "version": "1.0",
+        "type": "object",
+        "properties": {
+            "enabled": {"type": "boolean", "default": false, "description": "x"}
+        }
+    }"#;
+
+    #[test]
+    fn builder_with_directory() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(&schemas, "test", BOOL_SCHEMA);
+        create_values(&values, "test", r#"{"options": {"enabled": true}}"#);
+
+        let options = InitBuilder::new()
+            // without this, schemas wouldn't be found and this test would fail
+            .with_directory(temp.path())
+            .build_options()
+            .unwrap();
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+    }
+
+    #[test]
+    fn builder_with_schemas() {
+        let options = InitBuilder::new()
+            // without this, init would fail as schemas are never saved on disk
+            .with_schemas(&[("test", BOOL_SCHEMA)])
+            .build_options()
+            .unwrap();
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(false));
     }
 }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -23,6 +23,9 @@ pub enum OptionsError {
     #[error("Options not initialized - call init() first")]
     NotInitialized,
 
+    #[error("Options already initialized")]
+    AlreadyInitialized,
+
     #[error("Unknown namespace: {0}")]
     UnknownNamespace(String),
 
@@ -155,7 +158,7 @@ impl Options {
 }
 
 /// Builder for initializing the global options store.
-/// Define optional parameters with `with_*` methods, then finalize with `build()`
+/// Define optional parameters with `with_*` methods, then finalize with `init()`
 ///
 /// All settings are optional and independent:
 /// - `with_directory` overrides the base directory
@@ -197,11 +200,12 @@ impl<'a> InitBuilder<'a> {
 
     /// Initialize the global options store from the inputs.
     ///
-    /// Idempotent: if options are already initialized, returns `Ok(())` without
-    /// re-loading or applying any of this builder's settings.
-    pub fn build(self) -> Result<()> {
+    /// Returns [`OptionsError::AlreadyInitialized`] if the store is already
+    /// initialized, leaving the existing configuration untouched. Callers that
+    /// want a no-op in that case can ignore the error with `.ok()`.
+    pub fn init(self) -> Result<()> {
         if GLOBAL_OPTIONS.get().is_some() {
-            return Ok(());
+            return Err(OptionsError::AlreadyInitialized);
         }
 
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
@@ -212,23 +216,20 @@ impl<'a> InitBuilder<'a> {
         };
 
         let opts = Options::with_registry_and_values(registry, &dir.join("values"), self.callback)?;
-        let _ = GLOBAL_OPTIONS.set(opts);
-        Ok(())
+        GLOBAL_OPTIONS
+            .set(opts)
+            .map_err(|_| OptionsError::AlreadyInitialized)
     }
 }
 
-/// Initialize global options using fallback chain: `SENTRY_OPTIONS_DIR` env var,
-/// then `/etc/sentry-options` if it exists, otherwise `sentry-options/`.
+/// Initialize global options using the fallback chain: `SENTRY_OPTIONS_DIR` env
+/// var, then `/etc/sentry-options` if it exists, otherwise `sentry-options/`.
 ///
-/// Idempotent: if already initialized, returns `Ok(())` without re-loading.
-#[deprecated(since = "1.3.0", note = "use `InitBuilder::new().build()`")]
+/// Shorthand for `InitBuilder::new().init()`. Idempotent: if already
+/// initialized, returns `Ok(())` without re-loading. For directory, schema, or
+/// callback overrides, use [`InitBuilder`].
 pub fn init() -> Result<()> {
-    if GLOBAL_OPTIONS.get().is_some() {
-        return Ok(());
-    }
-    let opts = Options::new()?;
-    let _ = GLOBAL_OPTIONS.set(opts);
-    Ok(())
+    ignore_already_initialized(InitBuilder::new().init())
 }
 
 /// Like [`init`], but with a callback that fires whenever values are refreshed
@@ -236,15 +237,10 @@ pub fn init() -> Result<()> {
 /// `(namespace, delay_secs)`.
 #[deprecated(
     since = "1.3.0",
-    note = "use `InitBuilder::new().with_callback(cb).build()`"
+    note = "use `InitBuilder::new().with_callback(cb).init()`"
 )]
 pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<()> {
-    if GLOBAL_OPTIONS.get().is_some() {
-        return Ok(());
-    }
-    let opts = Options::new_with_propagation_callback(callback)?;
-    let _ = GLOBAL_OPTIONS.set(opts);
-    Ok(())
+    ignore_already_initialized(InitBuilder::new().with_callback(callback).init())
 }
 
 /// Initialize global options with schemas provided as in-memory JSON strings.
@@ -261,15 +257,18 @@ pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<(
 /// ```
 #[deprecated(
     since = "1.3.0",
-    note = "use `InitBuilder::new().with_schemas(s).build()`"
+    note = "use `InitBuilder::new().with_schemas(s).init()`"
 )]
 pub fn init_with_schemas(schemas: &[(&str, &str)]) -> Result<()> {
-    if GLOBAL_OPTIONS.get().is_some() {
-        return Ok(());
+    ignore_already_initialized(InitBuilder::new().with_schemas(schemas).init())
+}
+
+/// legacy, deprecated system was idempotent, this preserves the behaviour
+fn ignore_already_initialized(result: Result<()>) -> Result<()> {
+    match result {
+        Err(OptionsError::AlreadyInitialized) => Ok(()),
+        other => other,
     }
-    let opts = Options::from_schemas(schemas)?;
-    let _ = GLOBAL_OPTIONS.set(opts);
-    Ok(())
 }
 
 /// Get a namespace handle for accessing options.

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -164,7 +164,7 @@ impl Options {
 /// - `with_directory` overrides the base directory
 /// - `with_schemas` supplies schemas in memory instead of reading `{dir}/schemas/`
 /// - `with_callback` registers a callback that fires on every value refresh.
-/// ```
+///
 #[derive(Default)]
 pub struct InitBuilder<'a> {
     directory: Option<PathBuf>,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,15 +171,18 @@ A read — `options(ns).get(key)` — validates the loaded values against the sc
 
 ### Initialization
 
-`init()` must be called once at startup. Rust exposes three variants (it has no optional parameters); Python folds them into one function:
+Options must be initialized once at startup, guarded by a global `OnceLock`. Rust uses a builder, `InitBuilder`. Python folds the options into one function. In Rust, chain any subset of the `with_*` methods, then call `.init()`:
 
-| Function (Rust) | Behavior |
-|-----------------|----------|
-| `init()` | Resolve the directory and load schemas from disk |
-| `init_with_schemas(&[(ns, json)])` | Use schemas embedded in the binary via `include_str!`; values still load from disk |
-| `init_with_propagation_callback(cb)` | Like `init()`, plus a reload callback |
+| `InitBuilder` method | Behavior |
+|----------------------|----------|
+| _(no overrides)_ | Resolve the directory and load schemas from disk |
+| `.with_directory(path)` | Load schemas and values from a specific base directory |
+| `.with_schemas(&[(ns, json)])` | Use schemas embedded in the binary via `include_str!`. values still load from disk |
+| `.with_callback(cb)` | Register a reload callback |
 
-Python: `init(on_propagation=None)`. All forms are idempotent (guarded by a global `OnceLock`) — calling again is a no-op.
+`init()` is a shorthand for `InitBuilder::new().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None)`.
+
+The `init()` shorthand and Python's `init()` are idempotent — calling again is a no-op. The builder's `.init()` instead returns `OptionsError::AlreadyInitialized` when options are already initialized, so re-initializing with different settings is a loud error rather than a silent no-op.
 
 ### Refresh-on-read
 
@@ -192,7 +195,7 @@ End to end, a value change propagates as: ConfigMap update → ~1–2 min kubele
 
 ### Propagation metric
 
-When a refresh observes a newer `generated_at` than the previous snapshot, the propagation callback (`init_with_propagation_callback` in Rust, `on_propagation` in Python) fires with the namespace and the delay between generation and load — useful for measuring deploy lag.
+When a refresh observes a newer `generated_at` than the previous snapshot, the propagation callback (`InitBuilder::with_callback` in Rust, `on_propagation` in Python) fires with the namespace and the delay between generation and load — useful for measuring deploy lag.
 
 ## Feature Flag Evaluation
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -73,7 +73,7 @@ let cfg: IPAddress = serde_json::from_value(opts.get("database.config")?)?;
 
 To override a value locally in a test, use the corresponding guard.
 
-**Make sure to call `init()` at some point before the guard is reached**, e.g. in a setup function.
+**Make sure to initialize options at some point before the guard is reached**, e.g. in a startup function. In Python that's `init()`. In Rust use `init()` or [`InitBuilder`](./setup.md#4-initialize-sentry-options) for a custom directory or embedded schemas.
 
 ### Python
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,15 +104,28 @@ init()  # optional: init(on_propagation=Callback)
 
 #### Rust
 
-Rust doesn't support optional params, so the variants are separate functions:
+For the common case, the `init()` shorthand loads schemas from the fallback path:
 
-| Function                             | Use when                                                                                                                                      |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `init()`                             | Load schemas from the fallback path (`SENTRY_OPTIONS_DIR` → `/etc/sentry-options` → `./sentry-options/`). `Err`s if the directory is missing. |
-| `init_with_schemas(&[(ns, json)])`   | Embed schemas in the binary via `include_str!` so there's no disk dependency for schemas. Values are still read from disk and hot-reloaded.   |
-| `init_with_propagation_callback(cb)` | Like `init()`, plus the same on_propagation callback                                                                                          |
+```rust
+use sentry_options::init;
 
-More details about the `init()` and `propagation_callback` signature and usage can be found in the function documentation and [architecture doc](./architecture.md).
+init()?; // shorthand for `InitBuilder::new().init()`
+```
+
+To override the directory, embed schemas, or register a propagation callback, use `InitBuilder` and chain any subset of the `with_*` methods before `.init()`:
+
+```rust
+use sentry_options::InitBuilder;
+
+InitBuilder::new()
+    .with_schemas(&[("seer", include_str!("../sentry-options/schemas/seer/schema.json"))])
+    .with_callback(on_propagation)
+    .init()?;
+```
+
+`.init()` returns `OptionsError::AlreadyInitialized` if options are already initialized; ignore it with `.ok()` if that's expected. The standalone `init_with_schemas()` and `init_with_propagation_callback()` functions are **deprecated** in favor of the builder.
+
+More details about `InitBuilder` and the `propagation_callback` signature can be found in the function documentation and [architecture doc](./architecture.md).
 
 ### 5. Copy schemas folder and set `SENTRY_OPTIONS_DIR`
 
@@ -125,7 +138,7 @@ COPY sentry-options/schemas /etc/sentry-options/schemas
 ENV SENTRY_OPTIONS_DIR=/etc/sentry-options
 ```
 
-The `COPY` step can be omitted if using Rust `init_with_schemas()` but explicitly setting `SENTRY_OPTIONS_DIR` is still recommended.
+The `COPY` step can be omitted if using Rust `InitBuilder::with_schemas()` but explicitly setting `SENTRY_OPTIONS_DIR` is still recommended.
 
 ### Phase 1 Summary
 

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,6 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use sentry_options::{init, init_with_propagation_callback, init_with_schemas, options};
+use sentry_options::{init, options};
 
 /// An example usage of the Rust options client library
 /// Every 3 seconds, prints out the value of example-option, float-option, and bool-option


### PR DESCRIPTION
Rust client `init()` is getting cumbersome. We could do better with the builder pattern here. Creates a new public API for `init()` using `InitBuilder`. With it you can configure the directory, pass in static schemas, or a callback function.

Deprecates the old `init()` methods, they can be removed in a future release.

TODO:
- [x] update docs (readmes)
- [x] update internal examples and tests to use the new builder
- [x] add tests

**I will add unit tests for the callback property once I create a `get()` that forces a reload, thanks Jan!**