### PR TITLE
docs: update action docs and don't rebuild ci on pure docs updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,13 @@ on:
   push:
     branches: [main, test-me-*, release/**]
     tags: '*'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   pre-commit:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,8 +51,9 @@ In any workflow that runs in PRs and your main branch, add this reusable workflo
 ```yaml
 jobs:
   validate:
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@0b115be89b102d76beff8106bd4054365954282e
-    secrets: inherit
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@d112815b36c4f3fe6b22ce79ca3ca0a4701eabb7
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:
       schemas-path: sentry-options/schemas
 ```
@@ -64,7 +65,7 @@ In `.pre-commit-config.yaml`
 ```yaml
   # Generates sentry-options type stubs
   - repo: https://github.com/getsentry/sentry-options
-    rev: 0b115be89b102d76beff8106bd4054365954282e
+    rev: d112815b36c4f3fe6b22ce79ca3ca0a4701eabb7
     hooks:
       - id: sentry-options-gen-stubs
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,11 +51,7 @@ In any workflow that runs in PRs and your main branch, add this reusable workflo
 ```yaml
 jobs:
   validate:
-<<<<<<< update-action-docs
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@d112815b36c4f3fe6b22ce79ca3ca0a4701eabb7
-=======
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@0b115be89b102d76beff8106bd4054365954282e
->>>>>>> main
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@5792fdd90e854b6aa4747e89d61df07bfa6beaa6
     secrets:
       SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:


### PR DESCRIPTION
https://github.com/getsentry/getsentry/pull/20907 principle of least priv is good

also bumped to what getsentry is using (d112815b36c4f3fe6b22ce79ca3ca0a4701eabb7)