### PR TITLE
fix(ci): Instead of inheriting, explicitly include secret

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -15,6 +15,10 @@ on:
         description: "Build CLI from source instead of downloading release binary"
         type: boolean
         default: false
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY:
+        description: "Private key for the sentry-options-automator GitHub App. Only used when a schema deletion is detected, to check out sentry-options-automator."
+        required: false
 
 permissions:
   contents: read

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -52,7 +52,8 @@ In any workflow that runs in PRs and your main branch, add this reusable workflo
 jobs:
   validate:
     uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@0b115be89b102d76beff8106bd4054365954282e
-    secrets: inherit
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:
       schemas-path: sentry-options/schemas
 ```


### PR DESCRIPTION
`secrets: inherit` is broad doesn't follow least privilege principles. This explicitly calls out the key.

Callers will need to pass in this key in their own repo instead of using `inherit` (as seen in the doc)