### PR TITLE
fix(stubs): Fix missing feature flag definitions 

### DIFF
--- a/sentry-options-gen-stubs/__init__.py
+++ b/sentry-options-gen-stubs/__init__.py
@@ -150,6 +150,8 @@ def generate(schemas_dir: Path) -> str:
         'from typing import Literal, NotRequired, TypedDict, overload',
         '',
         'from sentry_options._core import ('
+        '\n    FeatureChecker,'
+        '\n    FeatureContext,'
         '\n    NotInitializedError,'
         '\n    NamespaceOptions,'
         '\n    OptionsError,'
@@ -157,12 +159,16 @@ def generate(schemas_dir: Path) -> str:
         '\n    SchemaError,'
         '\n    UnknownNamespaceError,'
         '\n    UnknownOptionError,'
+        '\n    features,'
         '\n    init,'
         '\n)',
         '',
         '__all__ = [',
         '    "init",',
         '    "options",',
+        '    "features",',
+        '    "FeatureChecker",',
+        '    "FeatureContext",',
         '    "NotInitializedError",',
         '    "NamespaceOptions",',
         '    "OptionsError",',

--- a/sentry-options/sentry_options/__init__.pyi
+++ b/sentry-options/sentry_options/__init__.pyi
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Literal, NotRequired, TypedDict, overload
 
 from sentry_options._core import (
+    FeatureChecker,
+    FeatureContext,
     NotInitializedError,
     NamespaceOptions,
     OptionsError,
@@ -12,12 +14,16 @@ from sentry_options._core import (
     SchemaError,
     UnknownNamespaceError,
     UnknownOptionError,
+    features,
     init,
 )
 
 __all__ = [
     "init",
     "options",
+    "features",
+    "FeatureChecker",
+    "FeatureContext",
     "NotInitializedError",
     "NamespaceOptions",
     "OptionsError",

--- a/tests/gen_stubs_test.py
+++ b/tests/gen_stubs_test.py
@@ -92,6 +92,38 @@ def test_generate_imports(schemas_dir: Path) -> None:
     assert 'from typing import Literal, NotRequired, TypedDict, overload' in output
 
 
+def test_generate_feature_api_exported(schemas_dir: Path) -> None:
+    """The namespace-independent feature API is re-exported from _core so
+    `sentry_options.features`/`FeatureChecker`/`FeatureContext` type-check."""
+    output = generate(schemas_dir)
+    for symbol in ('features', 'FeatureChecker', 'FeatureContext'):
+        assert f'    {symbol},' in output  # present in the _core import block
+        assert f'    "{symbol}",' in output  # present in __all__
+
+
+def test_feature_keys_do_not_emit_get_overloads(tmp_path: Path) -> None:
+    """`feature.`-prefixed entries are `{"$ref": "#/definitions/Feature"}` — they
+    are feature flags (read via features().has()), not options, so they must not
+    appear as get() overloads and must not break generation."""
+    ns_dir = tmp_path / 'svc'
+    ns_dir.mkdir()
+    (ns_dir / 'schema.json').write_text(
+        json.dumps({
+            'version': '1.0',
+            'type': 'object',
+            'properties': {
+                'real-option': {'type': 'boolean', 'default': False},
+                'feature.organizations:my-flag': {
+                    '$ref': '#/definitions/Feature',
+                },
+            },
+        }),
+    )
+    output = generate(tmp_path)
+    assert 'def get(self, key: Literal["real-option"]) -> bool' in output
+    assert 'feature.organizations:my-flag' not in output
+
+
 def test_unknown_type_raises(tmp_path: Path) -> None:
     ns_dir = tmp_path / 'svc'
     ns_dir.mkdir()


### PR DESCRIPTION
Recall that `.pyi` files will completely override normal types coming from the actual `.py` moduel.

We forgot to include the feature flag related definitions in the generation script, this includes it. 