### PR TITLE
feat(flags): Feature flag testing improvements

### DIFF
--- a/clients/python/python/sentry_options/testing.py
+++ b/clients/python/python/sentry_options/testing.py
@@ -12,11 +12,44 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Generator
+from typing import Any
 
 from sentry_options import OptionValue
 from sentry_options._core import _clear_override
 from sentry_options._core import _set_override
 from sentry_options._core import _validate_option
+
+# A feature flag value (the `Feature` object: owner/created_at/enabled/segments).
+# Deeply nested arbitrary JSON, so it's typed loosely rather than as OptionValue.
+Feature = dict[str, Any]
+
+
+def always_on() -> Feature:
+    """A feature value that is enabled for every context.
+
+    Use with :func:`override_options` to force a flag on in tests::
+
+        with override_options('seer', {'feature.my-flag': always_on()}):
+            assert features('seer').has('my-flag', ctx)
+    """
+    return {
+        'owner': {'team': 'testing'},
+        'created_at': '1970-01-01',
+        'segments': [{'name': 'always-on', 'rollout': 100, 'conditions': []}],
+    }
+
+
+def always_off() -> Feature:
+    """A feature value that is disabled for every context.
+
+    Use with :func:`override_options` to force a flag off in tests.
+    """
+    return {
+        'owner': {'team': 'testing'},
+        'created_at': '1970-01-01',
+        'enabled': False,
+        'segments': [],
+    }
 
 
 @contextlib.contextmanager
@@ -60,4 +93,4 @@ def override_options(
                 _set_override(namespace, key, prev)
 
 
-__all__ = ['override_options']
+__all__ = ['Feature', 'always_off', 'always_on', 'override_options']

--- a/clients/python/tests/options_override_test.py
+++ b/clients/python/tests/options_override_test.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import pytest
+from sentry_options import FeatureContext
+from sentry_options import features
 from sentry_options import options
 from sentry_options import SchemaError
+from sentry_options.testing import always_on
 from sentry_options.testing import override_options
 
 
@@ -86,4 +89,33 @@ def test_override_wrong_type_raises() -> None:
     with pytest.raises(SchemaError, match='not of type'):
         overrides = {'int-option': 'not-an-int'}
         with override_options('sentry-options-testing', overrides):
+            pass
+
+
+def test_override_feature_flag() -> None:
+    """A feature flag can be forced on via override_options, and has() reads it."""
+    ctx = FeatureContext({'organization_id': 1}, identity_fields=['organization_id'])
+    checker = features('sentry-options-testing')
+
+    # disabled-feature is enabled=False in the test values.
+    assert checker.has('organizations:disabled-feature', ctx) is False
+
+    with override_options(
+        'sentry-options-testing',
+        {'feature.organizations:disabled-feature': always_on()},
+    ):
+        assert checker.has('organizations:disabled-feature', ctx) is True
+
+    assert checker.has('organizations:disabled-feature', ctx) is False
+
+
+def test_override_malformed_feature_raises() -> None:
+    """A known feature key with a value that isn't a valid Feature fails
+    validation (rather than passing silently or raising UnknownOption)."""
+    with pytest.raises(SchemaError):
+        # Missing the required owner/created_at fields.
+        with override_options(
+            'sentry-options-testing',
+            {'feature.organizations:disabled-feature': {'segments': []}},
+        ):
             pass

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -138,7 +138,7 @@ impl Options {
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
-        if !schema.options.contains_key(key) {
+        if !schema.is_known_key(key) {
             return Err(OptionsError::UnknownOption {
                 namespace: namespace.into(),
                 key: key.into(),
@@ -386,20 +386,27 @@ mod tests {
         create_schema(
             &schemas,
             "test",
-            r#"{
+            r##"{
                 "version": "1.0",
                 "type": "object",
                 "properties": {
                     "has-value": {"type": "string", "default": "", "description": ""},
-                    "defined-with-default": {"type": "string", "default": "default_val", "description": "Opt"}
+                    "defined-with-default": {"type": "string", "default": "default_val", "description": "Opt"},
+                    "feature.organizations:my-flag": {"$ref": "#/definitions/Feature"}
                 }
-            }"#,
+            }"##,
         );
 
         let options = Options::from_directory(temp.path()).unwrap();
         assert!(options.isset("test", "not-defined").is_err());
         assert!(!options.isset("test", "defined-with-default").unwrap());
         assert!(options.isset("test", "has-value").unwrap());
+        // Feature keys are known (no UnknownOption error) but unset -> false.
+        assert!(
+            !options
+                .isset("test", "feature.organizations:my-flag")
+                .unwrap()
+        );
     }
 
     #[test]

--- a/clients/rust/src/testing.rs
+++ b/clients/rust/src/testing.rs
@@ -138,6 +138,37 @@ pub fn override_options(overrides: &[(&str, &str, Value)]) -> Result<OverrideGua
     Ok(OverrideGuard { previous })
 }
 
+/// A feature value that is enabled for every context.
+///
+/// Use with [`override_options`] to force a flag on in tests:
+///
+/// ```rust,ignore
+/// let _guard = override_options(&[(
+///     "seer",
+///     "feature.my-flag",
+///     always_on(),
+/// )]).unwrap();
+/// ```
+pub fn always_on() -> Value {
+    serde_json::json!({
+        "owner": {"team": "testing"},
+        "created_at": "1970-01-01",
+        "segments": [{"name": "always-on", "rollout": 100, "conditions": []}]
+    })
+}
+
+/// A feature value that is disabled for every context.
+///
+/// Use with [`override_options`] to force a flag off in tests.
+pub fn always_off() -> Value {
+    serde_json::json!({
+        "owner": {"team": "testing"},
+        "created_at": "1970-01-01",
+        "enabled": false,
+        "segments": []
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +249,65 @@ mod tests {
         }
 
         assert_eq!(get_override("sentry-options-testing", "int-option"), None);
+    }
+
+    #[test]
+    fn test_override_feature_flag() {
+        crate::init().unwrap();
+
+        let mut ctx = crate::FeatureContext::new();
+        ctx.insert("organization_id", json!(1));
+        ctx.identity_fields(vec!["organization_id"]);
+
+        // Baseline: no value in the store -> feature is off.
+        assert!(
+            !crate::features("sentry-options-testing").has("organizations:enabled-feature", &ctx)
+        );
+
+        {
+            let _guard = override_options(&[(
+                "sentry-options-testing",
+                "feature.organizations:enabled-feature",
+                always_on(),
+            )])
+            .unwrap();
+
+            assert!(
+                crate::features("sentry-options-testing")
+                    .has("organizations:enabled-feature", &ctx)
+            );
+        }
+
+        // Override removed when the guard drops.
+        assert!(
+            !crate::features("sentry-options-testing").has("organizations:enabled-feature", &ctx)
+        );
+    }
+
+    #[test]
+    fn test_always_off_forces_feature_off() {
+        crate::init().unwrap();
+
+        // enabled-feature matches org 123 in the test values.
+        let mut ctx = crate::FeatureContext::new();
+        ctx.insert("organization_id", json!(123));
+        ctx.identity_fields(vec!["organization_id"]);
+        assert!(
+            crate::features("sentry-options-testing").has("organizations:enabled-feature", &ctx)
+        );
+
+        {
+            let _guard = override_options(&[(
+                "sentry-options-testing",
+                "feature.organizations:enabled-feature",
+                always_off(),
+            )])
+            .unwrap();
+
+            assert!(
+                !crate::features("sentry-options-testing")
+                    .has("organizations:enabled-feature", &ctx)
+            );
+        }
     }
 }

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -152,6 +152,9 @@ pub struct OptionMetadata {
 pub struct NamespaceSchema {
     pub namespace: String,
     pub options: HashMap<String, OptionMetadata>,
+    /// `feature.`-prefixed keys. Kept separate from `options`
+    /// so they aren't involved in schema-evolution checks
+    feature_keys: HashSet<String>,
     /// All property keys from the schema, including feature flags that aren't in `options`.
     all_keys: HashSet<String>,
     validator: jsonschema::Validator,
@@ -193,12 +196,18 @@ impl NamespaceSchema {
         self.options.get(key).map(|meta| &meta.default)
     }
 
+    /// Whether `key` is a known key in this namespace, runtime
+    /// option or feature flag.
+    pub fn is_known_key(&self, key: &str) -> bool {
+        self.options.contains_key(key) || self.feature_keys.contains(key)
+    }
+
     /// Validate a single key-value pair against the schema.
     ///
     /// # Errors
     /// Returns error if the key doesn't exist or the value doesn't match the expected type.
     pub fn validate_option(&self, key: &str, value: &Value) -> ValidationResult<()> {
-        if !self.options.contains_key(key) {
+        if !self.is_known_key(key) {
             return Err(ValidationError::UnknownOption {
                 namespace: self.namespace.clone(),
                 key: key.to_string(),
@@ -444,14 +453,17 @@ impl SchemaRegistry {
 
         // Extract option metadata and validate types.
         let mut options = HashMap::new();
+        let mut feature_keys = HashSet::new();
         let mut all_keys = HashSet::new();
         let mut has_feature_keys = false;
         if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
             for (prop_name, prop_value) in properties {
                 all_keys.insert(prop_name.clone());
                 // Detect feature flags so that we can augment the schema with defs.
+                // They're tracked separately from `options` (see NamespaceSchema).
                 if prop_name.starts_with("feature.") {
                     has_feature_keys = true;
+                    feature_keys.insert(prop_name.clone());
                 }
                 if let (Some(prop_type), Some(default_value)) = (
                     prop_value.get("type").and_then(|t| t.as_str()),
@@ -496,6 +508,7 @@ impl SchemaRegistry {
         Ok(Arc::new(NamespaceSchema {
             namespace: namespace.to_string(),
             options,
+            feature_keys,
             all_keys,
             validator,
         }))
@@ -2123,6 +2136,58 @@ Error: \"version\" is a required property"
                 }),
             );
             assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_feature_flag_is_known_key() {
+            let temp_dir = TempDir::new().unwrap();
+            create_test_schema(&temp_dir, "test", FEATURE_SCHEMA);
+            let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+            let schema = registry.get("test").unwrap();
+            // make sure it's known...
+            assert!(schema.is_known_key("feature.organizations:fury-mode"));
+            // ...but not a runtime option
+            assert!(
+                !schema
+                    .options
+                    .contains_key("feature.organizations:fury-mode")
+            );
+            assert!(!schema.is_known_key("feature.organizations:does-not-exist"));
+        }
+
+        #[test]
+        fn test_validate_option_accepts_valid_feature() {
+            // Enables override_options(ns, {"feature.x": <Feature>}) with only the
+            // schema present (no value in the store).
+            let temp_dir = TempDir::new().unwrap();
+            create_test_schema(&temp_dir, "test", FEATURE_SCHEMA);
+            let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+            let schema = registry.get("test").unwrap();
+
+            let result = schema.validate_option(
+                "feature.organizations:fury-mode",
+                &json!({
+                    "owner": {"team": "hybrid-cloud"},
+                    "segments": [{"name": "all", "rollout": 100, "conditions": []}],
+                    "created_at": "2024-01-01"
+                }),
+            );
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_option_rejects_malformed_feature() {
+            // A known feature key with a value that isn't a valid Feature must fail
+            // validation (ValueError), not slip through as UnknownOption.
+            let temp_dir = TempDir::new().unwrap();
+            create_test_schema(&temp_dir, "test", FEATURE_SCHEMA);
+            let registry = SchemaRegistry::from_directory(temp_dir.path()).unwrap();
+            let schema = registry.get("test").unwrap();
+
+            // Missing required `owner` and `created_at`.
+            let result =
+                schema.validate_option("feature.organizations:fury-mode", &json!({"segments": []}));
+            assert!(matches!(result, Err(ValidationError::ValueError { .. })));
         }
     }
 


### PR DESCRIPTION
Feature flags were not being tracked at all (they weren't stored in `all_keys`) so you couldn't use `isset()` or the `override_options` APIs.

This PR enables these for feature flags, bringing parity with normal runtime options.

Also adds 2 useful testing fixtures, `always_on` and `always_off` that users can import in to force a feature flag's on or off state in testing