### PR TITLE
feat(client): Add a `get_forced` function to bypass the 5s staleness window

### DIFF
--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -28,6 +28,9 @@ class NamespaceOptions:
     def get(self, key: str) -> OptionValue: ...
     """Get the value for a named option. If no value is defined the default will be returned"""
 
+    def get_forced(self, key: str) -> OptionValue: ...
+    """Like get, but always refreshes. Refresh incurs a cost so this should only be used in testing."""
+
     def isset(self, key: str) -> bool: ...
     """See if an option is defined and has a value set."""
 

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -258,6 +258,16 @@ impl NamespaceOptions {
         json_to_py(py, &value)
     }
 
+    /// Like `get`, but always refreshes. Refresh incurs a cost so this should
+    /// only be used in testing.
+    fn get_forced(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let value = self
+            .options
+            .get_forced(&self.namespace, key)
+            .map_err(options_err)?;
+        json_to_py(py, &value)
+    }
+
     /// Check if an option has a defined value.
     fn isset(&self, key: &str) -> PyResult<bool> {
         self.options

--- a/clients/python/tests/propagation_test.py
+++ b/clients/python/tests/propagation_test.py
@@ -91,6 +91,30 @@ def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> No
     )
 
 
+def test_get_forced_sees_change_without_waiting(tmp_path: Path) -> None:
+    options_dir = _make_options_dir(tmp_path)
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
+    _run(
+        f"""\
+        import json
+        from sentry_options import init, options
+
+        init()
+        opts = options("test-ns")
+        assert opts.get("enabled") is True
+
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": False}}}}, f)
+
+        # Cached get() still returns the old value within the 5s threshold.
+        assert opts.get("enabled") is True
+        # get_forced() bypasses the threshold and sees the change, no sleep needed.
+        assert opts.get_forced("enabled") is False
+        """,
+        options_dir,
+    )
+
+
 def test_propagation_callback_not_called_without_generated_at(tmp_path: Path) -> None:
     _run(
         f"""\

--- a/clients/python/tests/propagation_test.py
+++ b/clients/python/tests/propagation_test.py
@@ -2,7 +2,9 @@
 
 Each test spins up a subprocess with its own ``SENTRY_OPTIONS_DIR`` so the
 Rust ``OnceLock`` starts fresh and ``init(on_propagation=...)`` can register
-a real Python callback.
+a real Python callback. Refreshes are triggered synchronously with
+``get_forced``, which bypasses the refresh threshold so the tests don't have
+to wait it out.
 """
 from __future__ import annotations
 
@@ -12,9 +14,6 @@ import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
-
-# 5 s refresh threshold + up to 1 s jitter + margin
-REFRESH_WAIT = 7
 
 
 def _make_options_dir(root: Path, *, generated_at: str | None = None) -> Path:
@@ -69,17 +68,16 @@ def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> No
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
     _run(
         f"""\
-        import json, time
+        import json
         from sentry_options import init, options
 
         results = []
         init(on_propagation=lambda ns, delay: results.append((ns, delay)))
         assert options("test-ns").get("enabled") is True
 
-        time.sleep({REFRESH_WAIT})
         with open("{values_file}", "w") as f:
             json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
-        options("test-ns").get("enabled")
+        options("test-ns").get_forced("enabled")
 
         assert len(results) == 1, f"Expected 1 callback, got {{len(results)}}: {{results}}"
         ns, delay = results[0]
@@ -116,21 +114,25 @@ def test_get_forced_sees_change_without_waiting(tmp_path: Path) -> None:
 
 
 def test_propagation_callback_not_called_without_generated_at(tmp_path: Path) -> None:
+    options_dir = _make_options_dir(tmp_path)
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
     _run(
         f"""\
-        import time
+        import json
         from sentry_options import init, options
 
         results = []
         init(on_propagation=lambda ns, delay: results.append((ns, delay)))
         options("test-ns").get("enabled")
 
-        time.sleep({REFRESH_WAIT})
-        options("test-ns").get("enabled")
+        # Change the values (forcing a reload) but with no generated_at.
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": False}}}}, f)
+        options("test-ns").get_forced("enabled")
 
         assert len(results) == 0, f"Expected no callbacks, got {{len(results)}}"
         """,
-        _make_options_dir(tmp_path),
+        options_dir,
     )
 
 
@@ -139,7 +141,7 @@ def test_propagation_callback_exception_does_not_crash(tmp_path: Path) -> None:
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
     _run(
         f"""\
-        import json, time
+        import json
         from sentry_options import init, options
 
         def boom(ns, delay):
@@ -148,11 +150,10 @@ def test_propagation_callback_exception_does_not_crash(tmp_path: Path) -> None:
         init(on_propagation=boom)
         assert options("test-ns").get("enabled") is True
 
-        time.sleep({REFRESH_WAIT})
         with open("{values_file}", "w") as f:
             json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
 
-        val = options("test-ns").get("enabled")
+        val = options("test-ns").get_forced("enabled")
         assert val is True
         """,
         options_dir,
@@ -164,28 +165,25 @@ def test_propagation_callback_receives_multiple_updates(tmp_path: Path) -> None:
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
     _run(
         f"""\
-        import json, time
+        import json
         from sentry_options import init, options
 
         results = []
         init(on_propagation=lambda ns, delay: results.append((ns, delay)))
         options("test-ns").get("enabled")
 
-        time.sleep({REFRESH_WAIT})
         with open("{values_file}", "w") as f:
             json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T19:00:00+00:00"}}, f)
-        options("test-ns").get("enabled")
+        options("test-ns").get_forced("enabled")
         assert len(results) == 1, f"After 1st update: expected 1, got {{len(results)}}"
 
-        time.sleep({REFRESH_WAIT})
         with open("{values_file}", "w") as f:
             json.dump({{"options": {{"enabled": True}}, "generated_at": "2024-01-21T20:00:00+00:00"}}, f)
-        options("test-ns").get("enabled")
+        options("test-ns").get_forced("enabled")
         assert len(results) == 2, f"After 2nd update: expected 2, got {{len(results)}}"
 
         assert all(ns == "test-ns" for ns, _ in results)
         assert all(d > 0.0 for _, d in results)
         """,
         options_dir,
-        timeout=45,
     )

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -85,6 +85,16 @@ impl Options {
 
     /// Get an option value, returning the schema default if not set.
     pub fn get(&self, namespace: &str, key: &str) -> Result<Value> {
+        self.get_inner(namespace, key, false)
+    }
+
+    /// Like [`get`](Self::get), but always refreshes. Refresh incurs a cost
+    /// so this should only be used in testing.
+    pub fn get_forced(&self, namespace: &str, key: &str) -> Result<Value> {
+        self.get_inner(namespace, key, true)
+    }
+
+    fn get_inner(&self, namespace: &str, key: &str, force_reload: bool) -> Result<Value> {
         if let Some(value) = testing::get_override(namespace, key) {
             return Ok(value);
         }
@@ -95,7 +105,12 @@ impl Options {
             .get(namespace)
             .ok_or_else(|| OptionsError::UnknownNamespace(namespace.to_string()))?;
 
-        let values_guard = self.store.load();
+        let values_guard = if force_reload {
+            self.store.force_load()
+        } else {
+            self.store.load()
+        };
+
         if let Some(ns_values) = values_guard.get(namespace)
             && let Some(value) = ns_values.get(key)
         {
@@ -221,6 +236,12 @@ impl NamespaceOptions {
     /// Get an option value, returning the schema default if not set.
     pub fn get(&self, key: &str) -> Result<Value> {
         self.options.get(&self.namespace, key)
+    }
+
+    /// Like [`get`](Self::get), but always refreshes. Refresh incurs a cost
+    /// so this should only be used in testing.
+    pub fn get_forced(&self, key: &str) -> Result<Value> {
+        self.options.get_forced(&self.namespace, key)
     }
 
     /// Check if an option has a key defined, or if the default is being used.
@@ -452,5 +473,35 @@ mod tests {
     fn test_from_schemas_invalid_json() {
         let result = SchemaRegistry::from_schemas(&[("test", "not valid json")]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_forced_sees_change() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(
+            &schemas,
+            "test",
+            r#"{
+                "version": "1.0",
+                "type": "object",
+                "properties": {
+                    "enabled": {"type": "boolean", "default": false, "description": "x"}
+                }
+            }"#,
+        );
+        create_values(&values, "test", r#"{"options": {"enabled": true}}"#);
+
+        let options = Options::from_directory(temp.path()).unwrap();
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+
+        create_values(&values, "test", r#"{"options": {"enabled": false}}"#);
+
+        // Cached read still returns the old value
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+        // Forced read picks up the change
+        assert_eq!(options.get_forced("test", "enabled").unwrap(), json!(false));
     }
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -126,7 +126,9 @@ Just like in Python, use `get_forced()` to bypass the 5s cache threshold and see
 ```rust
 // import, create a values file, init(), etc...
 fs::write("sentry-options/values/seer/values.json", br#"{"options": {"autofix.enabled": false}}"#)?;
+// Cached get() still returns the old value within the 5s threshold.
 assert_eq!(options("seer").get("autofix.enabled").unwrap(), true);
+// get_forced() bypasses the cache and returns the updated value immediately.
 assert_eq!(options("seer").get_forced("autofix.enabled").unwrap(), false);
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -90,6 +90,20 @@ def test_timeout():
     assert options('seer').get('autofix.enabled')
 ```
 
+If you want to test option values changing, use `get_forced()` instead of `get()`. Even in tests,
+`get()` will not refresh if it already did so <5 seconds ago. `get_forced()` will always refresh.
+
+```python
+# import, create values_file, init(), etc...
+# {enabled: True} by default.
+with open(values_file, "w") as f:
+    json.dump({"options": {"enabled": False}}, f)
+# Cached get() still returns the old value within the 5s threshold.
+assert opts.get("enabled") is True
+# get_forced() bypasses the threshold and sees the change, no sleep needed.
+assert opts.get_forced("enabled") is False
+```
+
 ### Rust
 
 A little bit different with Rust, pass in a static array of `(namespace, option, value)` tuples.
@@ -106,6 +120,14 @@ fn test_timeout() {
   let _guard = override_options(&[("seer", "autofix.enabled", true.into())]).unwrap();
   assert_eq!(options("seer").get("autofix.enabled").unwrap(), true);
 }
+```
+
+Just like in Python, use `get_forced()` to bypass the 5s cache threshold and see the updated value immediately.
+```rust
+// import, create a values file, init(), etc...
+fs::write("sentry-options/values/seer/values.json", br#"{"options": {"autofix.enabled": false}}"#)?;
+assert_eq!(options("seer").get("autofix.enabled").unwrap(), true);
+assert_eq!(options("seer").get_forced("autofix.enabled").unwrap(), false);
 ```
 
 ## Setting an option value locally

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -704,6 +704,16 @@ impl ValuesStore {
         self.values.load()
     }
 
+    /// Like [`load`](Self::load), but always refreshes, ignoring the staleness
+    /// threshold. The mtime check still applies, so unchanged files are not
+    /// re-read from disk.
+    pub fn force_load(&self) -> arc_swap::Guard<Arc<ValuesByNamespace>> {
+        let now_ns = self.baseline.elapsed().as_nanos() as u64;
+        let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);
+        self.refresh(last_ns, now_ns);
+        self.values.load()
+    }
+
     fn maybe_refresh(&self) {
         let now_ns = self.baseline.elapsed().as_nanos() as u64;
         let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);


### PR DESCRIPTION
This is useful for testing. You no longer need to change an option value, wait 5 seconds, then make the check. This is slow and potentially flaky.

I'm exposing it as public so client library consumers can write their own tests with this as well.

**using this internally, tests now run in 0.48s instead of 35s**