### PR TITLE
feat(client): Improve the Options builder interface

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -44,6 +44,16 @@ pub struct Options {
 }
 
 impl Options {
+    /// Returns a builder for constructing an [`Options`] instance or
+    /// initializing the global store.
+    ///
+    /// Configure optional parameters with the `with_*` methods, then finalize
+    /// with [`InitBuilder::build`] for a standalone instance or
+    /// [`InitBuilder::init`] for the global store.
+    pub fn builder<'a>() -> InitBuilder<'a> {
+        InitBuilder::new()
+    }
+
     /// Load options using fallback chain: `SENTRY_OPTIONS_DIR` env var, then `/etc/sentry-options`
     /// if it exists, otherwise `sentry-options/`.
     /// Expects `{dir}/schemas/` and `{dir}/values/` subdirectories.
@@ -251,9 +261,9 @@ impl<'a> InitBuilder<'a> {
 /// Initialize global options using the fallback chain: `SENTRY_OPTIONS_DIR` env
 /// var, then `/etc/sentry-options` if it exists, otherwise `sentry-options/`.
 ///
-/// Shorthand for `InitBuilder::new().init()`. Idempotent: if already
+/// Shorthand for `Options::builder().init()`. Idempotent: if already
 /// initialized, returns `Ok(())` without re-loading. For directory, schema, or
-/// callback overrides, use [`InitBuilder`].
+/// callback overrides, use [`Options::builder`].
 pub fn init() -> Result<()> {
     ignore_already_initialized(InitBuilder::new().init())
 }
@@ -263,7 +273,7 @@ pub fn init() -> Result<()> {
 /// `(namespace, delay_secs)`.
 #[deprecated(
     since = "1.3.0",
-    note = "use `InitBuilder::new().with_callback(cb).init()`"
+    note = "use `Options::builder().with_callback(cb).init()`"
 )]
 pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<()> {
     ignore_already_initialized(InitBuilder::new().with_callback(callback).init())
@@ -283,7 +293,7 @@ pub fn init_with_propagation_callback(callback: PropagationCallback) -> Result<(
 /// ```
 #[deprecated(
     since = "1.3.0",
-    note = "use `InitBuilder::new().with_schemas(s).init()`"
+    note = "use `Options::builder().with_schemas(s).init()`"
 )]
 pub fn init_with_schemas(schemas: &[(&str, &str)]) -> Result<()> {
     ignore_already_initialized(InitBuilder::new().with_schemas(schemas).init())
@@ -581,7 +591,7 @@ mod tests {
         create_schema(&schemas, "test", BOOL_SCHEMA);
         create_values(&values, "test", r#"{"options": {"enabled": true}}"#);
 
-        let options = InitBuilder::new()
+        let options = Options::builder()
             // without this, schemas wouldn't be found and this test would fail
             .with_directory(temp.path())
             .build()
@@ -591,7 +601,7 @@ mod tests {
 
     #[test]
     fn builder_with_schemas() {
-        let options = InitBuilder::new()
+        let options = Options::builder()
             // without this, init would fail as schemas are never saved on disk
             .with_schemas(&[("test", BOOL_SCHEMA)])
             .build()

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -208,8 +208,8 @@ impl<'a> InitBuilder<'a> {
 
     /// Register a callback that fires `(namespace, delay_secs)` whenever values
     /// are refreshed with a new `generated_at` timestamp.
-    pub fn with_callback(mut self, callback: PropagationCallback) -> Self {
-        self.callback = Some(callback);
+    pub fn with_callback(mut self, callback: impl Fn(&str, f64) + Send + Sync + 'static) -> Self {
+        self.callback = Some(Box::new(callback));
         self
     }
 

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -223,13 +223,20 @@ impl<'a> InitBuilder<'a> {
             return Err(OptionsError::AlreadyInitialized);
         }
         GLOBAL_OPTIONS
-            .set(self.build_options()?)
+            .set(self.build()?)
             .map_err(|_| OptionsError::AlreadyInitialized)
     }
 
-    /// Helper to return an `Options` with the configured inputs.
-    /// Does not touch the global `OnceLock`.
-    fn build_options(self) -> Result<Options> {
+    /// Builds an [`Options`] instance from the inputs, without initializing
+    /// the global store.
+    ///
+    /// Use this when you want to manage the lifetime of the options store yourself, or
+    /// when you want to have multiple independent options stores in the same process.
+    ///
+    /// Use [`init`] if you want to initialize the global store.
+    ///
+    /// Returns an error if the schemas are invalid or the values cannot be loaded.
+    pub fn build(self) -> Result<Options> {
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
         let registry = match self.schemas {
@@ -577,7 +584,7 @@ mod tests {
         let options = InitBuilder::new()
             // without this, schemas wouldn't be found and this test would fail
             .with_directory(temp.path())
-            .build_options()
+            .build()
             .unwrap();
         assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
     }
@@ -587,7 +594,7 @@ mod tests {
         let options = InitBuilder::new()
             // without this, init would fail as schemas are never saved on disk
             .with_schemas(&[("test", BOOL_SCHEMA)])
-            .build_options()
+            .build()
             .unwrap();
         assert_eq!(options.get("test", "enabled").unwrap(), json!(false));
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,16 +171,16 @@ A read — `options(ns).get(key)` — validates the loaded values against the sc
 
 ### Initialization
 
-Options must be initialized once at startup, guarded by a global `OnceLock`. Rust uses a builder, `InitBuilder`. Python folds the options into one function. In Rust, chain any subset of the `with_*` methods, then call `.init()`:
+Options must be initialized once at startup, guarded by a global `OnceLock`. Rust uses a builder obtained from `Options::builder()`. Python folds the options into one function. In Rust, chain any subset of the `with_*` methods, then call `.init()`:
 
-| `InitBuilder` method | Behavior |
+| Builder method | Behavior |
 |----------------------|----------|
 | _(no overrides)_ | Resolve the directory and load schemas from disk |
 | `.with_directory(path)` | Load schemas and values from a specific base directory |
 | `.with_schemas(&[(ns, json)])` | Use schemas embedded in the binary via `include_str!`. values still load from disk |
 | `.with_callback(cb)` | Register a reload callback |
 
-`init()` is a shorthand for `InitBuilder::new().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None)`.
+`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None)`.
 
 The `init()` shorthand and Python's `init()` are idempotent — calling again is a no-op. The builder's `.init()` instead returns `OptionsError::AlreadyInitialized` when options are already initialized, so re-initializing with different settings is a loud error rather than a silent no-op.
 
@@ -195,7 +195,7 @@ End to end, a value change propagates as: ConfigMap update → ~1–2 min kubele
 
 ### Propagation metric
 
-When a refresh observes a newer `generated_at` than the previous snapshot, the propagation callback (`InitBuilder::with_callback` in Rust, `on_propagation` in Python) fires with the namespace and the delay between generation and load — useful for measuring deploy lag.
+When a refresh observes a newer `generated_at` than the previous snapshot, the propagation callback (`Options::builder().with_callback` in Rust, `on_propagation` in Python) fires with the namespace and the delay between generation and load — useful for measuring deploy lag.
 
 ## Feature Flag Evaluation
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -73,7 +73,7 @@ let cfg: IPAddress = serde_json::from_value(opts.get("database.config")?)?;
 
 To override a value locally in a test, use the corresponding guard.
 
-**Make sure to initialize options at some point before the guard is reached**, e.g. in a startup function. In Python that's `init()`. In Rust use `init()` or [`InitBuilder`](./setup.md#4-initialize-sentry-options) for a custom directory or embedded schemas.
+**Make sure to initialize options at some point before the guard is reached**, e.g. in a startup function. In Python that's `init()`. In Rust use `init()` or [`Options::builder()`](./setup.md#4-initialize-sentry-options) for a custom directory or embedded schemas.
 
 ### Python
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -135,15 +135,15 @@ For the common case, the `init()` shorthand loads schemas from the fallback path
 ```rust
 use sentry_options::init;
 
-init()?; // shorthand for `InitBuilder::new().init()`
+init()?; // shorthand for `Options::builder().init()`
 ```
 
-To override the directory, embed schemas, or register a propagation callback, use `InitBuilder` and chain any subset of the `with_*` methods before `.init()`:
+To override the directory, embed schemas, or register a propagation callback, use `Options::builder()` and chain any subset of the `with_*` methods before `.init()`:
 
 ```rust
-use sentry_options::InitBuilder;
+use sentry_options::Options;
 
-InitBuilder::new()
+Options::builder()
     .with_schemas(&[("seer", include_str!("../sentry-options/schemas/seer/schema.json"))])
     .with_callback(on_propagation)
     .init()?;
@@ -151,7 +151,7 @@ InitBuilder::new()
 
 `.init()` returns `OptionsError::AlreadyInitialized` if options are already initialized; ignore it with `.ok()` if that's expected. The standalone `init_with_schemas()` and `init_with_propagation_callback()` functions are **deprecated** in favor of the builder.
 
-More details about `InitBuilder` and the `propagation_callback` signature can be found in the function documentation and [architecture doc](./architecture.md).
+More details about `Options::builder()` and the `propagation_callback` signature can be found in the function documentation and [architecture doc](./architecture.md).
 
 ### 5. Copy schemas folder and set `SENTRY_OPTIONS_DIR`
 
@@ -164,7 +164,7 @@ COPY sentry-options/schemas /etc/sentry-options/schemas
 ENV SENTRY_OPTIONS_DIR=/etc/sentry-options
 ```
 
-The `COPY` step can be omitted if using Rust `InitBuilder::with_schemas()` but explicitly setting `SENTRY_OPTIONS_DIR` is still recommended.
+The `COPY` step can be omitted if using Rust `Options::builder().with_schemas()` but explicitly setting `SENTRY_OPTIONS_DIR` is still recommended.
 
 ### Phase 1 Summary
 


### PR DESCRIPTION
Several related improvements to the Rust `Options` builder, making it the primary way to construct or initialize an options store:

- **`Options::builder()` entry point.** Callers now reach the builder through `Options::builder()` rather than naming `InitBuilder::new()` directly. All documentation (code doc comments, deprecation notes, setup, architecture, and options docs) now uses `Options::builder()`.
- **Public `build()`.** The builder exposes a public `build()` that constructs an `Options` instance directly, without initializing the global `OnceLock`. This lets callers manage the store's lifetime themselves or run multiple independent stores in the same process; `init()` continues to use it internally.
- **Ergonomic `with_callback`.** `with_callback` now accepts any matching closure and boxes it internally, so callers no longer need to construct a box themselves.