### PR TITLE
feat: Add manual refresh and configurable refresh threshold

### DIFF
--- a/clients/python/python/sentry_options/__init__.py
+++ b/clients/python/python/sentry_options/__init__.py
@@ -17,6 +17,7 @@ from sentry_options._core import NamespaceOptions
 from sentry_options._core import NotInitializedError
 from sentry_options._core import options
 from sentry_options._core import OptionsError
+from sentry_options._core import refresh
 from sentry_options._core import SchemaError
 from sentry_options._core import UnknownNamespaceError
 from sentry_options._core import UnknownOptionError
@@ -35,6 +36,7 @@ __all__ = [
     'options',
     'OptionValue',
     'OptionsError',
+    'refresh',
     'SchemaError',
     'UnknownNamespaceError',
     'UnknownOptionError',

--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -6,7 +6,10 @@ _Primitive = Union[str, int, float, bool]
 _Object = dict[str, _Primitive]
 OptionValue = Union[_Primitive, _Object, list[Union[_Primitive, _Object]]]
 
-def init(on_propagation: Callable[[str, float], None] | None = None) -> None: ...
+def init(
+    on_propagation: Callable[[str, float], None] | None = None,
+    refresh_threshold: float | None = 5.0,
+) -> None: ...
 """
 Initialize the options extension with schema and
 values defined in environment variables or production paths.
@@ -16,6 +19,22 @@ Parameters
 on_propagation : callable, optional
     Callback invoked when values are refreshed with a new ``generated_at``
     timestamp. Receives ``(namespace: str, delay_secs: float)``.
+refresh_threshold : float | None
+    Staleness threshold in seconds for refresh-on-read (default: 5.0).
+    Pass ``None`` to disable refresh-on-read entirely; values then only
+    change via ``refresh()``.
+"""
+
+def refresh() -> bool: ...
+"""
+Refresh values from disk, ignoring the staleness threshold.
+
+Returns whether a new snapshot was published, i.e. the files changed on disk
+and reloaded successfully. On error the previous snapshot is retained and
+served. Calling this more often than the threshold guarantees reads never
+refresh inline.
+
+Raises NotInitializedError if ``init()`` has not been called.
 """
 
 def options(namespace: str) -> NamespaceOptions: ...

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -2,10 +2,11 @@
 
 use std::collections::HashMap;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use ::sentry_options::{
-    FeatureChecker as RustFeatureChecker, FeatureContext as RustFeatureContext,
-    Options as RustOptions, OptionsError as RustOptionsError,
+    DEFAULT_REFRESH_THRESHOLD, FeatureChecker as RustFeatureChecker,
+    FeatureContext as RustFeatureContext, Options as RustOptions, OptionsError as RustOptionsError,
 };
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -193,27 +194,60 @@ impl PyFeatureChecker {
 /// Optionally accepts an `on_propagation` callback that fires whenever values
 /// are refreshed with a new `generated_at` timestamp. The callback receives
 /// `(namespace: str, delay_secs: float)`.
+///
+/// `refresh_threshold` is the staleness threshold in seconds for
+/// refresh-on-read (default: 5.0). Pass `None` to disable refresh-on-read
+/// entirely; values then only change via `refresh()`.
 #[pyfunction]
-#[pyo3(signature = (on_propagation=None))]
-fn init(on_propagation: Option<Py<PyAny>>) -> PyResult<()> {
+#[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64())))]
+fn init(on_propagation: Option<Py<PyAny>>, refresh_threshold: Option<f64>) -> PyResult<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
     }
-    let opts = match on_propagation {
+
+    let refresh_threshold = match refresh_threshold {
+        Some(secs) if !secs.is_finite() || secs < 0.0 => {
+            return Err(PyValueError::new_err(
+                "refresh_threshold must be a non-negative number or None",
+            ));
+        }
+        Some(secs) => Some(Duration::from_secs_f64(secs)),
+        None => None,
+    };
+
+    let mut builder = RustOptions::builder().with_refresh_threshold(refresh_threshold);
+    if let Some(cb) = on_propagation {
         // `Py<PyAny>` is `Send + Sync`; the closure re-acquires the GIL for the
         // call, so the callback can run on whichever thread triggers a refresh.
-        Some(cb) => RustOptions::new_with_propagation_callback(Box::new(move |ns, delay| {
+        builder = builder.with_callback(move |ns, delay| {
             Python::attach(|py| {
                 if let Err(e) = cb.call1(py, (ns, delay)) {
                     e.print(py);
                 }
             });
-        }))
-        .map_err(options_err)?,
-        None => RustOptions::new().map_err(options_err)?,
-    };
+        });
+    }
+    let opts = builder.build().map_err(options_err)?;
     let _ = GLOBAL_OPTIONS.set(opts);
     Ok(())
+}
+
+/// Refresh values from disk, ignoring the staleness threshold.
+///
+/// Returns whether a new snapshot was published, i.e. the files changed on
+/// disk and reloaded successfully. On error the previous snapshot is retained
+/// and served. Calling this more often than the threshold guarantees reads
+/// never refresh inline.
+///
+/// Raises NotInitializedError if init() has not been called.
+#[pyfunction]
+fn refresh(py: Python<'_>) -> PyResult<bool> {
+    let opts = GLOBAL_OPTIONS.get().ok_or_else(|| {
+        NotInitializedError::new_err("Options not initialized - call init() first")
+    })?;
+    // Release the GIL: the reload does file IO, and the propagation callback
+    // re-acquires the GIL itself.
+    py.detach(|| opts.refresh()).map_err(options_err)
 }
 
 /// Get a namespace handle for accessing options.
@@ -327,6 +361,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(init, m)?)?;
     m.add_function(wrap_pyfunction!(options, m)?)?;
     m.add_function(wrap_pyfunction!(features, m)?)?;
+    m.add_function(wrap_pyfunction!(refresh, m)?)?;
     // Classes
     m.add_class::<NamespaceOptions>()?;
     m.add_class::<PyFeatureContext>()?;

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
 import pytest
 from sentry_options import init
 
@@ -8,3 +15,56 @@ from sentry_options import init
 def init_options(tmp_path_factory: pytest.TempPathFactory):
     """Initialize options once for the test session."""
     init()
+
+
+def make_options_dir(root: Path, *, generated_at: str | None = None) -> Path:
+    """Create an options directory with a ``test-ns`` schema and values file."""
+    options_dir = root / 'opts'
+    schemas_dir = options_dir / 'schemas' / 'test-ns'
+    values_dir = options_dir / 'values' / 'test-ns'
+    schemas_dir.mkdir(parents=True)
+    values_dir.mkdir(parents=True)
+
+    schemas_dir.joinpath('schema.json').write_text(
+        json.dumps(
+            {
+                'version': '1.0',
+                'type': 'object',
+                'properties': {
+                    'enabled': {
+                        'type': 'boolean',
+                        'default': False,
+                        'description': 'Enabled',
+                    },
+                },
+            },
+        ),
+    )
+
+    values: dict = {'options': {'enabled': True}}
+    if generated_at is not None:
+        values['generated_at'] = generated_at
+    values_dir.joinpath('values.json').write_text(json.dumps(values))
+
+    return options_dir
+
+
+def run_isolated(script: str, options_dir: Path, timeout: int = 30, **env_extra: str) -> None:
+    """Run a Python script in a subprocess with its own ``SENTRY_OPTIONS_DIR``.
+
+    Each subprocess gets a fresh Rust ``OnceLock``, so scripts can call
+    ``init(...)`` with their own settings.
+    """
+    env = os.environ.copy()
+    env['SENTRY_OPTIONS_DIR'] = str(options_dir)
+    env.update(env_extra)
+    result = subprocess.run(
+        [sys.executable, '-c', dedent(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, (
+        f"Script failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/clients/python/tests/propagation_test.py
+++ b/clients/python/tests/propagation_test.py
@@ -8,65 +8,15 @@ to wait it out.
 """
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import sys
 from pathlib import Path
-from textwrap import dedent
 
-
-def _make_options_dir(root: Path, *, generated_at: str | None = None) -> Path:
-    options_dir = root / 'opts'
-    schemas_dir = options_dir / 'schemas' / 'test-ns'
-    values_dir = options_dir / 'values' / 'test-ns'
-    schemas_dir.mkdir(parents=True)
-    values_dir.mkdir(parents=True)
-
-    schemas_dir.joinpath('schema.json').write_text(
-        json.dumps(
-            {
-                'version': '1.0',
-                'type': 'object',
-                'properties': {
-                    'enabled': {
-                        'type': 'boolean',
-                        'default': False,
-                        'description': 'Enabled',
-                    },
-                },
-            },
-        ),
-    )
-
-    values: dict = {'options': {'enabled': True}}
-    if generated_at is not None:
-        values['generated_at'] = generated_at
-    values_dir.joinpath('values.json').write_text(json.dumps(values))
-
-    return options_dir
-
-
-def _run(script: str, options_dir: Path, timeout: int = 30, **env_extra: str) -> None:
-    env = os.environ.copy()
-    env['SENTRY_OPTIONS_DIR'] = str(options_dir)
-    env.update(env_extra)
-    result = subprocess.run(
-        [sys.executable, '-c', dedent(script)],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    assert result.returncode == 0, (
-        f"Script failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    )
+from conftest import make_options_dir, run_isolated
 
 
 def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> None:
-    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
+    options_dir = make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
-    _run(
+    run_isolated(
         f"""\
         import json
         from sentry_options import init, options
@@ -90,9 +40,9 @@ def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> No
 
 
 def test_get_forced_sees_change_without_waiting(tmp_path: Path) -> None:
-    options_dir = _make_options_dir(tmp_path)
+    options_dir = make_options_dir(tmp_path)
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
-    _run(
+    run_isolated(
         f"""\
         import json
         from sentry_options import init, options
@@ -114,9 +64,9 @@ def test_get_forced_sees_change_without_waiting(tmp_path: Path) -> None:
 
 
 def test_propagation_callback_not_called_without_generated_at(tmp_path: Path) -> None:
-    options_dir = _make_options_dir(tmp_path)
+    options_dir = make_options_dir(tmp_path)
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
-    _run(
+    run_isolated(
         f"""\
         import json
         from sentry_options import init, options
@@ -137,9 +87,9 @@ def test_propagation_callback_not_called_without_generated_at(tmp_path: Path) ->
 
 
 def test_propagation_callback_exception_does_not_crash(tmp_path: Path) -> None:
-    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
+    options_dir = make_options_dir(tmp_path, generated_at='2024-01-21T18:30:00+00:00')
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
-    _run(
+    run_isolated(
         f"""\
         import json
         from sentry_options import init, options
@@ -161,9 +111,9 @@ def test_propagation_callback_exception_does_not_crash(tmp_path: Path) -> None:
 
 
 def test_propagation_callback_receives_multiple_updates(tmp_path: Path) -> None:
-    options_dir = _make_options_dir(tmp_path, generated_at='2024-01-21T18:00:00+00:00')
+    options_dir = make_options_dir(tmp_path, generated_at='2024-01-21T18:00:00+00:00')
     values_file = options_dir / 'values' / 'test-ns' / 'values.json'
-    _run(
+    run_isolated(
         f"""\
         import json
         from sentry_options import init, options

--- a/clients/python/tests/propagation_test.py
+++ b/clients/python/tests/propagation_test.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from conftest import make_options_dir, run_isolated
+from conftest import make_options_dir
+from conftest import run_isolated
 
 
 def test_propagation_callback_fires_on_generated_at_change(tmp_path: Path) -> None:

--- a/clients/python/tests/refresh_test.py
+++ b/clients/python/tests/refresh_test.py
@@ -1,0 +1,72 @@
+"""E2E tests for manual refresh and the configurable staleness threshold.
+
+Each test spins up a subprocess with its own ``SENTRY_OPTIONS_DIR`` so the
+Rust ``OnceLock`` starts fresh and ``init(refresh_threshold=...)`` takes
+effect.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from conftest import make_options_dir, run_isolated
+
+
+def test_manual_refresh_with_disabled_threshold(tmp_path: Path) -> None:
+    options_dir = make_options_dir(tmp_path)
+    values_file = options_dir / 'values' / 'test-ns' / 'values.json'
+    run_isolated(
+        f"""\
+        import json
+        from sentry_options import init, options, refresh
+
+        init(refresh_threshold=None)
+        opts = options("test-ns")
+        assert opts.get("enabled") is True
+
+        with open("{values_file}", "w") as f:
+            json.dump({{"options": {{"enabled": False}}}}, f)
+
+        # With refresh-on-read disabled, reads never pick up the change.
+        assert opts.get("enabled") is True
+        # A manual refresh does.
+        assert refresh() is True
+        assert opts.get("enabled") is False
+        # Nothing changed since the last refresh.
+        assert refresh() is False
+        """,
+        options_dir,
+    )
+
+
+def test_refresh_before_init_raises(tmp_path: Path) -> None:
+    options_dir = make_options_dir(tmp_path)
+    run_isolated(
+        """\
+        from sentry_options import NotInitializedError, refresh
+
+        try:
+            refresh()
+        except NotInitializedError:
+            pass
+        else:
+            raise AssertionError("Expected NotInitializedError")
+        """,
+        options_dir,
+    )
+
+
+def test_init_rejects_negative_refresh_threshold(tmp_path: Path) -> None:
+    options_dir = make_options_dir(tmp_path)
+    run_isolated(
+        """\
+        from sentry_options import init
+
+        try:
+            init(refresh_threshold=-1.0)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Expected ValueError")
+        """,
+        options_dir,
+    )

--- a/clients/python/tests/refresh_test.py
+++ b/clients/python/tests/refresh_test.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from conftest import make_options_dir, run_isolated
+from conftest import make_options_dir
+from conftest import run_isolated
 
 
 def test_manual_refresh_with_disabled_threshold(tmp_path: Path) -> None:

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -6,8 +6,9 @@ pub use features::{FeatureChecker, FeatureContext, features};
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
-pub use sentry_options_validation::PropagationCallback;
+pub use sentry_options_validation::{DEFAULT_REFRESH_THRESHOLD, PropagationCallback};
 use sentry_options_validation::{
     SchemaRegistry, ValidationError, ValuesStore, resolve_options_dir,
 };
@@ -66,34 +67,52 @@ impl Options {
     pub fn new_with_propagation_callback(callback: PropagationCallback) -> Result<Self> {
         let dir = resolve_options_dir();
         let registry = SchemaRegistry::from_directory(&dir.join("schemas"))?;
-        Self::with_registry_and_values(registry, &dir.join("values"), Some(callback))
+        Self::with_registry_and_values(
+            registry,
+            &dir.join("values"),
+            Some(DEFAULT_REFRESH_THRESHOLD),
+            Some(callback),
+        )
     }
 
     /// Load options from a specific directory (useful for testing).
     /// Expects `{base_dir}/schemas/` and `{base_dir}/values/` subdirectories.
     pub fn from_directory(base_dir: &Path) -> Result<Self> {
         let registry = SchemaRegistry::from_directory(&base_dir.join("schemas"))?;
-        Self::with_registry_and_values(registry, &base_dir.join("values"), None)
+        Self::with_registry_and_values(
+            registry,
+            &base_dir.join("values"),
+            Some(DEFAULT_REFRESH_THRESHOLD),
+            None,
+        )
     }
 
     /// Load options with schemas provided as in-memory JSON strings.
     /// Values are loaded from disk using the standard fallback chain.
     pub fn from_schemas(schemas: &[(&str, &str)]) -> Result<Self> {
         let registry = SchemaRegistry::from_schemas(schemas)?;
-        Self::with_registry_and_values(registry, &resolve_options_dir().join("values"), None)
+        Self::with_registry_and_values(
+            registry,
+            &resolve_options_dir().join("values"),
+            Some(DEFAULT_REFRESH_THRESHOLD),
+            None,
+        )
     }
 
     fn with_registry_and_values(
         registry: SchemaRegistry,
         values_dir: &Path,
+        refresh_threshold: Option<Duration>,
         callback: Option<PropagationCallback>,
     ) -> Result<Self> {
-        let registry = Arc::new(registry);
-        let store = match callback {
-            Some(cb) => ValuesStore::with_propagation_callback(registry, values_dir, cb)?,
-            None => ValuesStore::new(registry, values_dir)?,
-        };
-        Ok(Self { store })
+        let mut builder = ValuesStore::builder(Arc::new(registry), values_dir)
+            .with_refresh_threshold(refresh_threshold);
+        if let Some(cb) = callback {
+            builder = builder.with_callback(cb);
+        }
+        Ok(Self {
+            store: builder.build()?,
+        })
     }
 
     /// Get an option value, returning the schema default if not set.
@@ -102,9 +121,24 @@ impl Options {
     }
 
     /// Like [`get`](Self::get), but always refreshes. Refresh incurs a cost
-    /// so this should only be used in testing.
+    /// so this should only be used in testing; use [`refresh`](Self::refresh)
+    /// to drive refreshes in production.
     pub fn get_forced(&self, namespace: &str, key: &str) -> Result<Value> {
         self.get_inner(namespace, key, true)
+    }
+
+    /// Refreshes values from disk, ignoring the staleness threshold.
+    ///
+    /// Returns whether a new snapshot was published, i.e. the files changed
+    /// on disk (by mtime) and reloaded successfully. On error the previous
+    /// snapshot is retained and served. Callbacks registered with
+    /// [`InitBuilder::with_callback`] fire on the calling thread before this
+    /// returns.
+    ///
+    /// Any call resets the refresh-on-read timer, so calling this more often
+    /// than the staleness threshold guarantees reads never refresh inline.
+    pub fn refresh(&self) -> Result<bool> {
+        Ok(self.store.refresh()?)
     }
 
     fn get_inner(&self, namespace: &str, key: &str, force_reload: bool) -> Result<Value> {
@@ -189,12 +223,15 @@ impl Options {
 /// - `with_directory` overrides the base directory
 /// - `with_schemas` supplies schemas in memory instead of reading `{dir}/schemas/`
 /// - `with_callback` registers a callback that fires on every value refresh.
+/// - `with_refresh_threshold` overrides or disables the staleness threshold
+///   for refresh-on-read.
 ///
 #[derive(Default)]
 pub struct InitBuilder<'a> {
     directory: Option<PathBuf>,
     schemas: Option<&'a [(&'a str, &'a str)]>,
     callback: Option<PropagationCallback>,
+    refresh_threshold: Option<Option<Duration>>,
 }
 
 impl<'a> InitBuilder<'a> {
@@ -220,6 +257,16 @@ impl<'a> InitBuilder<'a> {
     /// are refreshed with a new `generated_at` timestamp.
     pub fn with_callback(mut self, callback: impl Fn(&str, f64) + Send + Sync + 'static) -> Self {
         self.callback = Some(Box::new(callback));
+        self
+    }
+
+    /// Overrides the staleness threshold for refresh-on-read.
+    ///
+    /// Defaults to [`DEFAULT_REFRESH_THRESHOLD`] (5 seconds). Pass `None` to
+    /// disable refresh-on-read entirely; values then only change via
+    /// [`Options::refresh`].
+    pub fn with_refresh_threshold(mut self, threshold: impl Into<Option<Duration>>) -> Self {
+        self.refresh_threshold = Some(threshold.into());
         self
     }
 
@@ -254,7 +301,15 @@ impl<'a> InitBuilder<'a> {
             None => SchemaRegistry::from_directory(&dir.join("schemas"))?,
         };
 
-        Options::with_registry_and_values(registry, &dir.join("values"), self.callback)
+        let refresh_threshold = self
+            .refresh_threshold
+            .unwrap_or(Some(DEFAULT_REFRESH_THRESHOLD));
+        Options::with_registry_and_values(
+            registry,
+            &dir.join("values"),
+            refresh_threshold,
+            self.callback,
+        )
     }
 }
 
@@ -627,5 +682,54 @@ mod tests {
         assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
         // Forced read picks up the change
         assert_eq!(options.get_forced("test", "enabled").unwrap(), json!(false));
+    }
+
+    #[test]
+    fn builder_refresh_threshold_none_with_manual_refresh() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(&schemas, "test", BOOL_SCHEMA);
+        create_values(&values, "test", r#"{"options": {"enabled": true}}"#);
+
+        let options = Options::builder()
+            .with_directory(temp.path())
+            .with_refresh_threshold(None)
+            .build()
+            .unwrap();
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+
+        create_values(&values, "test", r#"{"options": {"enabled": false}}"#);
+
+        // With refresh-on-read disabled, reads never pick up the change.
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+        // A manual refresh does.
+        assert!(options.refresh().unwrap());
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(false));
+        // Nothing changed since the last refresh.
+        assert!(!options.refresh().unwrap());
+    }
+
+    #[test]
+    fn builder_refresh_threshold_custom() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(&schemas, "test", BOOL_SCHEMA);
+        create_values(&values, "test", r#"{"options": {"enabled": true}}"#);
+
+        let options = Options::builder()
+            .with_directory(temp.path())
+            .with_refresh_threshold(Duration::ZERO)
+            .build()
+            .unwrap();
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+
+        create_values(&values, "test", r#"{"options": {"enabled": false}}"#);
+
+        // A zero threshold refreshes on every read.
+        assert_eq!(options.get("test", "enabled").unwrap(), json!(false));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,8 +179,9 @@ Options must be initialized once at startup, guarded by a global `OnceLock`. Rus
 | `.with_directory(path)` | Load schemas and values from a specific base directory |
 | `.with_schemas(&[(ns, json)])` | Use schemas embedded in the binary via `include_str!`. values still load from disk |
 | `.with_callback(cb)` | Register a reload callback |
+| `.with_refresh_threshold(t)` | Override the refresh-on-read staleness threshold (default 5 s); `None` disables refresh-on-read |
 
-`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None)`.
+`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None, refresh_threshold=5.0)`.
 
 The `init()` shorthand and Python's `init()` are idempotent — calling again is a no-op. The builder's `.init()` instead returns `OptionsError::AlreadyInitialized` when options are already initialized, so re-initializing with different settings is a loud error rather than a silent no-op.
 
@@ -189,9 +190,18 @@ The `init()` shorthand and Python's `init()` are idempotent — calling again is
 There is no background thread. Values are refreshed lazily, on the reading thread:
 
 - The current snapshot lives in an `ArcSwap`, so reads are lock-free.
-- On a read, if the snapshot is older than a **5-second threshold** (plus a small per-call jitter derived from the stack address, so threads don't all refresh on the same boundary), the reading thread re-stats and re-reads the files and publishes the new snapshot. Concurrent refreshers are harmless — last writer wins. On an I/O error the timestamp is still advanced to avoid hammering the disk.
+- On a read, if the snapshot is older than a **staleness threshold** — 5 seconds by default, configurable via `with_refresh_threshold` in Rust and `refresh_threshold=` in Python — plus a small per-call jitter derived from the stack address (so threads don't all refresh on the same boundary), the reading thread re-stats and re-reads the files and publishes the new snapshot. Concurrent refreshers are harmless — last writer wins. On an I/O error the timestamp is still advanced to avoid hammering the disk.
 
 End to end, a value change propagates as: ConfigMap update → ~1–2 min kubelet sync to the mounted file → ≤5 s until the next read picks it up. No pod restart is required.
+
+### Manual refresh
+
+`Options::refresh()` in Rust (`sentry_options.refresh()` in Python) reloads values immediately, ignoring the staleness threshold, and returns whether anything changed on disk. Files with an unchanged mtime are not re-read. On error the previous snapshot is retained.
+
+Every refresh — lazy or manual — resets the staleness timer. Two consequences:
+
+- **Preempting hot-path IO**: driving `refresh()` from your own timer more often than the threshold guarantees that reads never stat or parse files inline.
+- **Manual-only mode**: passing `None` as the refresh threshold disables refresh-on-read entirely; values then only change when `refresh()` is called. Combined with the reload callback, this supports eagerly re-deserializing options into a typed struct off the hot path whenever `refresh()` reports a change.
 
 ### Propagation metric
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -123,10 +123,12 @@ Call `init()` once, as early in startup as possible (e.g. right where you initia
 ```python
 from sentry_options import init
 
-init()  # optional: init(on_propagation=Callback)
+init()  # optional: init(on_propagation=Callback, refresh_threshold=5.0)
 ```
 
-`on_propagation` is a callback fired whenever values reload, useful for collecting metrics.
+`on_propagation` is a callback fired whenever values reload, useful for collecting metrics. `refresh_threshold` sets the staleness window for refresh-on-read (default `5.0` seconds).
+
+**Important:** Passing `None` into `refresh_threshold` will completely disable automatic refreshes and must be triggered manually via `sentry_options.refresh`.
 
 #### Rust
 
@@ -138,7 +140,7 @@ use sentry_options::init;
 init()?; // shorthand for `Options::builder().init()`
 ```
 
-To override the directory, embed schemas, or register a propagation callback, use `Options::builder()` and chain any subset of the `with_*` methods before `.init()`:
+To override the directory, embed schemas, change the refresh threshold, or register a propagation callback, use `Options::builder()` and chain any subset of the `with_*` methods before `.init()`:
 
 ```rust
 use sentry_options::Options;
@@ -146,8 +148,11 @@ use sentry_options::Options;
 Options::builder()
     .with_schemas(&[("seer", include_str!("../sentry-options/schemas/seer/schema.json"))])
     .with_callback(on_propagation)
+    .with_refresh_threshold(Some(Duration::from_secs(2)))  // or `None` to disable refresh-on-read
     .init()?;
 ```
+
+**Important:** Passing `None` into `refresh_threshold` will completely disable automatic refreshes and must be triggered manually via `sentry_options.refresh`.
 
 `.init()` returns `OptionsError::AlreadyInitialized` if options are already initialized; ignore it with `.ok()` if that's expected. The standalone `init_with_schemas()` and `init_with_propagation_callback()` functions are **deprecated** in favor of the builder.
 

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -34,7 +34,7 @@ const VALUES_FILE_NAME: &str = "values.json";
 /// Default minimum age of a cached values snapshot before a read triggers a
 /// refresh. A per-thread jitter of up to 1 s is added on top to spread the
 /// reload across threads.
-const REFRESH_THRESHOLD: Duration = Duration::from_secs(5);
+pub const DEFAULT_REFRESH_THRESHOLD: Duration = Duration::from_secs(5);
 
 /// Production path where options are deployed via config map
 pub const PRODUCTION_OPTIONS_DIR: &str = "/etc/sentry-options";
@@ -633,7 +633,9 @@ pub struct ValuesStore {
     values: ArcSwap<ValuesByNamespace>,
     baseline: Instant,
     last_refresh_offset_ns: AtomicU64,
-    refresh_threshold: Duration,
+    /// Staleness threshold for refresh-on-read; `None` disables it, so values
+    /// only change via [`refresh`](Self::refresh).
+    refresh_threshold: Option<Duration>,
     /// Last known `generated_at` per namespace, used to detect value changes.
     /// Uses ArcSwap for lock-free, fork-safe access.
     last_generated_at: ArcSwap<HashMap<String, String>>,
@@ -644,50 +646,71 @@ pub struct ValuesStore {
     last_mtimes: ArcSwap<HashMap<String, SystemTime>>,
 }
 
-impl ValuesStore {
-    /// Build a store and perform the initial values load synchronously.
-    pub fn new(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValidationResult<Self> {
-        Self::build(registry, values_dir, REFRESH_THRESHOLD, None)
+/// Builder for constructing a [`ValuesStore`].
+///
+/// Created via [`ValuesStore::builder`]. Configure optional parameters with
+/// the `with_*` methods, then finalize with [`build`](Self::build).
+pub struct ValuesStoreBuilder {
+    registry: Arc<SchemaRegistry>,
+    values_dir: PathBuf,
+    refresh_threshold: Option<Duration>,
+    on_propagation: Option<PropagationCallback>,
+}
+
+impl ValuesStoreBuilder {
+    /// Overrides the staleness threshold for refresh-on-read.
+    ///
+    /// Defaults to [`DEFAULT_REFRESH_THRESHOLD`]. Pass `None` to disable
+    /// refresh-on-read entirely; values then only change via
+    /// [`ValuesStore::refresh`]. A zero threshold refreshes on every read.
+    pub fn with_refresh_threshold(mut self, threshold: impl Into<Option<Duration>>) -> Self {
+        self.refresh_threshold = threshold.into();
+        self
     }
 
-    /// Build a store with a callback that fires whenever new values are detected.
+    /// Registers a callback that fires whenever new values are detected.
     /// The callback receives `(namespace, delay_secs)` on each value change.
-    pub fn with_propagation_callback(
-        registry: Arc<SchemaRegistry>,
-        values_dir: &Path,
-        callback: PropagationCallback,
-    ) -> ValidationResult<Self> {
-        Self::build(registry, values_dir, REFRESH_THRESHOLD, Some(callback))
+    pub fn with_callback(mut self, callback: PropagationCallback) -> Self {
+        self.on_propagation = Some(callback);
+        self
     }
 
-    /// Internal constructor. `Duration::ZERO` threshold makes every `load()`
-    /// refresh, which is useful for tests.
-    fn build(
-        registry: Arc<SchemaRegistry>,
-        values_dir: &Path,
-        refresh_threshold: Duration,
-        on_propagation: Option<PropagationCallback>,
-    ) -> ValidationResult<Self> {
+    /// Builds the store and performs the initial values load synchronously.
+    pub fn build(self) -> ValidationResult<ValuesStore> {
+        let values_dir = &self.values_dir;
         if !should_suppress_missing_dir_errors() && fs::metadata(values_dir).is_err() {
             eprintln!("Values directory does not exist: {}", values_dir.display());
         }
 
         let baseline = Instant::now();
-        let initial_mtimes = Self::collect_mtimes(&registry, values_dir);
-        let (initial, generated_at_by_namespace) = registry.load_values_json(values_dir)?;
+        let initial_mtimes = ValuesStore::collect_mtimes(&self.registry, values_dir);
+        let (initial, generated_at_by_namespace) = self.registry.load_values_json(values_dir)?;
         let last_refresh_offset_ns = AtomicU64::new(baseline.elapsed().as_nanos() as u64);
 
-        Ok(Self {
-            registry,
-            values_dir: values_dir.to_path_buf(),
+        Ok(ValuesStore {
+            registry: self.registry,
+            values_dir: self.values_dir,
             values: ArcSwap::from_pointee(initial),
             baseline,
             last_refresh_offset_ns,
-            refresh_threshold,
+            refresh_threshold: self.refresh_threshold,
             last_generated_at: ArcSwap::from_pointee(generated_at_by_namespace),
-            on_propagation,
+            on_propagation: self.on_propagation,
             last_mtimes: ArcSwap::from_pointee(initial_mtimes),
         })
+    }
+}
+
+impl ValuesStore {
+    /// Returns a builder for constructing a store from the given registry and
+    /// values directory.
+    pub fn builder(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValuesStoreBuilder {
+        ValuesStoreBuilder {
+            registry,
+            values_dir: values_dir.to_path_buf(),
+            refresh_threshold: Some(DEFAULT_REFRESH_THRESHOLD),
+            on_propagation: None,
+        }
     }
 
     /// The registry the store was constructed with.
@@ -721,20 +744,39 @@ impl ValuesStore {
     /// threshold. The mtime check still applies, so unchanged files are not
     /// re-read from disk.
     pub fn force_load(&self) -> arc_swap::Guard<Arc<ValuesByNamespace>> {
-        let now_ns = self.baseline.elapsed().as_nanos() as u64;
-        let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);
-        self.refresh(last_ns, now_ns);
+        if let Err(e) = self.refresh() {
+            self.log_refresh_error(&e);
+        }
         self.values.load()
     }
 
+    /// Refreshes values from disk, ignoring the staleness threshold.
+    ///
+    /// Returns whether a new snapshot was published, i.e. the files changed
+    /// on disk (by mtime) and reloaded successfully. On error the previous
+    /// snapshot is retained. Propagation callbacks fire on the calling thread
+    /// before this returns.
+    ///
+    /// Any call resets the refresh-on-read timer, so calling this more often
+    /// than the threshold guarantees reads never refresh inline.
+    pub fn refresh(&self) -> ValidationResult<bool> {
+        let now_ns = self.baseline.elapsed().as_nanos() as u64;
+        let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);
+        self.refresh_at(last_ns, now_ns)
+    }
+
     fn maybe_refresh(&self) {
+        let Some(threshold) = self.refresh_threshold else {
+            return;
+        };
+
         let now_ns = self.baseline.elapsed().as_nanos() as u64;
         let last_ns = self.last_refresh_offset_ns.load(Ordering::Acquire);
         let elapsed_ns = now_ns.saturating_sub(last_ns);
-        let threshold_ns = self.refresh_threshold.as_nanos() as u64;
+        let threshold_ns = threshold.as_nanos() as u64;
         // Skip jitter for a zero threshold so callers (chiefly tests) can
         // force every read to refresh.
-        let jitter_ns = if self.refresh_threshold.is_zero() {
+        let jitter_ns = if threshold.is_zero() {
             0
         } else {
             stack_jitter_ns()
@@ -744,10 +786,20 @@ impl ValuesStore {
             return;
         }
 
-        self.refresh(last_ns, now_ns);
+        if let Err(e) = self.refresh_at(last_ns, now_ns) {
+            self.log_refresh_error(&e);
+        }
     }
 
-    fn refresh(&self, observed_last_ns: u64, now_ns: u64) {
+    fn log_refresh_error(&self, error: &ValidationError) {
+        eprintln!(
+            "Failed to reload values from {}: {}",
+            self.values_dir.display(),
+            error
+        );
+    }
+
+    fn refresh_at(&self, observed_last_ns: u64, now_ns: u64) -> ValidationResult<bool> {
         let current_mtimes = Self::collect_mtimes(&self.registry, &self.values_dir);
         if *self.last_mtimes.load().as_ref() == current_mtimes {
             let _ = self.last_refresh_offset_ns.compare_exchange(
@@ -756,7 +808,7 @@ impl ValuesStore {
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             );
-            return;
+            return Ok(false);
         }
 
         let result = self.registry.load_values_json(&self.values_dir);
@@ -772,16 +824,9 @@ impl ValuesStore {
             Ok((new_values, generated_at)) => {
                 self.values.store(Arc::new(new_values));
                 self.last_mtimes.store(Arc::new(current_mtimes));
-                Some(generated_at)
+                Ok(generated_at)
             }
-            Err(e) => {
-                eprintln!(
-                    "Failed to reload values from {}: {}",
-                    self.values_dir.display(),
-                    e
-                );
-                None
-            }
+            Err(e) => Err(e),
         };
 
         // Bump the timestamp regardless of success. On failure, the bumped
@@ -795,35 +840,37 @@ impl ValuesStore {
             Ordering::Relaxed,
         );
 
+        let new_generated_at = new_generated_at?;
+
         // Fire the propagation callback after the CAS so other threads see a
         // fresh timestamp and don't redundantly re-read from disk while a
         // potentially slow callback (e.g. Python/GIL) executes.
-        if let Some(new_generated_at) = new_generated_at {
-            let last = self.last_generated_at.load();
-            if *last.as_ref() != new_generated_at {
-                if let Some(callback) = &self.on_propagation {
-                    let applied_at = Utc::now();
-                    for (ns, ts) in &new_generated_at {
-                        if last.get(ns).is_some_and(|old| old == ts) {
-                            continue;
-                        }
-                        match propagation_delay_secs(&applied_at, ts) {
-                            Some(delay) => {
-                                if let Err(e) =
-                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                        callback(ns, delay)
-                                    }))
-                                {
-                                    eprintln!("Propagation callback panicked for {ns}: {:?}", e);
-                                }
+        let last = self.last_generated_at.load();
+        if *last.as_ref() != new_generated_at {
+            if let Some(callback) = &self.on_propagation {
+                let applied_at = Utc::now();
+                for (ns, ts) in &new_generated_at {
+                    if last.get(ns).is_some_and(|old| old == ts) {
+                        continue;
+                    }
+                    match propagation_delay_secs(&applied_at, ts) {
+                        Some(delay) => {
+                            if let Err(e) =
+                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    callback(ns, delay)
+                                }))
+                            {
+                                eprintln!("Propagation callback panicked for {ns}: {:?}", e);
                             }
-                            None => eprintln!("Bad generated_at for {ns}: {ts}"),
                         }
+                        None => eprintln!("Bad generated_at for {ns}: {ts}"),
                     }
                 }
-                self.last_generated_at.store(Arc::new(new_generated_at));
             }
+            self.last_generated_at.store(Arc::new(new_generated_at));
         }
+
+        Ok(true)
     }
 }
 
@@ -1639,15 +1686,13 @@ Error: \"version\" is a required property"
         let events_clone = events.clone();
 
         let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-        let store = ValuesStore::build(
-            registry,
-            &values_dir,
-            Duration::ZERO,
-            Some(Box::new(move |ns, delay| {
+        let store = ValuesStore::builder(registry, &values_dir)
+            .with_refresh_threshold(Duration::ZERO)
+            .with_callback(Box::new(move |ns, delay| {
                 events_clone.lock().unwrap().push((ns.to_string(), delay));
-            })),
-        )
-        .unwrap();
+            }))
+            .build()
+            .unwrap();
 
         // Initial load doesn't emit (generated_at set during construction).
         assert!(events.lock().unwrap().is_empty());
@@ -1700,7 +1745,10 @@ Error: \"version\" is a required property"
 
         let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
         // No callback — should not panic or error.
-        let store = ValuesStore::build(registry, &values_dir, Duration::ZERO, None).unwrap();
+        let store = ValuesStore::builder(registry, &values_dir)
+            .with_refresh_threshold(Duration::ZERO)
+            .build()
+            .unwrap();
         let _ = store.load();
         // Just verify it doesn't crash.
     }
@@ -1758,13 +1806,11 @@ Error: \"version\" is a required property"
         let values_file = write_ns(base, "test", "2024-01-21T18:30:00+00:00");
 
         let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
-        let store = ValuesStore::build(
-            registry,
-            &base.join("values"),
-            Duration::ZERO,
-            Some(Box::new(|_ns, _delay| panic!("callback boom"))),
-        )
-        .unwrap();
+        let store = ValuesStore::builder(registry, &base.join("values"))
+            .with_refresh_threshold(Duration::ZERO)
+            .with_callback(Box::new(|_ns, _delay| panic!("callback boom")))
+            .build()
+            .unwrap();
 
         // Trigger a change so the panicking callback fires; load() must not unwind.
         fs::write(
@@ -1790,15 +1836,13 @@ Error: \"version\" is a required property"
         let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
         let events_clone = events.clone();
         let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
-        let store = ValuesStore::build(
-            registry,
-            &base.join("values"),
-            Duration::ZERO,
-            Some(Box::new(move |ns, delay| {
+        let store = ValuesStore::builder(registry, &base.join("values"))
+            .with_refresh_threshold(Duration::ZERO)
+            .with_callback(Box::new(move |ns, delay| {
                 events_clone.lock().unwrap().push((ns.to_string(), delay));
-            })),
-        )
-        .unwrap();
+            }))
+            .build()
+            .unwrap();
 
         // Change generated_at to a malformed value: detected as a change, but
         // unparseable, so no event is emitted.
@@ -1821,15 +1865,13 @@ Error: \"version\" is a required property"
         let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
         let events_clone = events.clone();
         let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
-        let store = ValuesStore::build(
-            registry,
-            &base.join("values"),
-            Duration::ZERO,
-            Some(Box::new(move |ns, delay| {
+        let store = ValuesStore::builder(registry, &base.join("values"))
+            .with_refresh_threshold(Duration::ZERO)
+            .with_callback(Box::new(move |ns, delay| {
                 events_clone.lock().unwrap().push((ns.to_string(), delay));
-            })),
-        )
-        .unwrap();
+            }))
+            .build()
+            .unwrap();
 
         // Only beta's generated_at changes; alpha is untouched.
         fs::write(
@@ -2259,14 +2301,25 @@ Error: \"version\" is a required property"
 
         fn store_with_zero_threshold(schemas_dir: &Path, values_dir: &Path) -> ValuesStore {
             let registry = Arc::new(SchemaRegistry::from_directory(schemas_dir).unwrap());
-            ValuesStore::build(registry, values_dir, Duration::ZERO, None).unwrap()
+            ValuesStore::builder(registry, values_dir)
+                .with_refresh_threshold(Duration::ZERO)
+                .build()
+                .unwrap()
+        }
+
+        fn store_without_refresh_on_read(schemas_dir: &Path, values_dir: &Path) -> ValuesStore {
+            let registry = Arc::new(SchemaRegistry::from_directory(schemas_dir).unwrap());
+            ValuesStore::builder(registry, values_dir)
+                .with_refresh_threshold(None)
+                .build()
+                .unwrap()
         }
 
         #[test]
         fn test_initial_load_populates_values() {
             let (_temp, schemas_dir, values_dir) = setup_store_test();
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let store = ValuesStore::new(registry, &values_dir).unwrap();
+            let store = ValuesStore::builder(registry, &values_dir).build().unwrap();
 
             let guard = store.load();
             assert_eq!(guard["ns1"]["enabled"], json!(true));
@@ -2279,7 +2332,7 @@ Error: \"version\" is a required property"
             // read should still see the cached value.
             let (_temp, schemas_dir, values_dir) = setup_store_test();
             let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
-            let store = ValuesStore::new(registry, &values_dir).unwrap();
+            let store = ValuesStore::builder(registry, &values_dir).build().unwrap();
 
             // Confirm initial value, then modify the file.
             assert_eq!(store.load()["ns1"]["enabled"], json!(true));
@@ -2365,6 +2418,130 @@ Error: \"version\" is a required property"
             for h in handles {
                 assert_eq!(h.join().unwrap(), json!(7));
             }
+        }
+
+        #[test]
+        fn test_refresh_returns_true_on_change_false_when_unchanged() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = store_without_refresh_on_read(&schemas_dir, &values_dir);
+
+            // Nothing changed on disk since construction.
+            assert!(!store.refresh().unwrap());
+
+            fs::write(
+                values_dir.join("ns1").join("values.json"),
+                r#"{"options": {"enabled": false}}"#,
+            )
+            .unwrap();
+            assert!(store.refresh().unwrap());
+
+            // Unchanged again after the reload.
+            assert!(!store.refresh().unwrap());
+        }
+
+        #[test]
+        fn test_disabled_threshold_never_refreshes_on_read() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = store_without_refresh_on_read(&schemas_dir, &values_dir);
+
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
+            fs::write(
+                values_dir.join("ns1").join("values.json"),
+                r#"{"options": {"enabled": false}}"#,
+            )
+            .unwrap();
+
+            // Reads never refresh with a disabled threshold.
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
+
+            // A manual refresh picks up the change.
+            assert!(store.refresh().unwrap());
+            assert_eq!(store.load()["ns1"]["enabled"], json!(false));
+        }
+
+        #[test]
+        fn test_refresh_error_keeps_snapshot_and_recovers() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let store = store_without_refresh_on_read(&schemas_dir, &values_dir);
+            let ns1_values = values_dir.join("ns1").join("values.json");
+
+            fs::write(&ns1_values, "not json").unwrap();
+            assert!(store.refresh().is_err());
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
+
+            fs::write(&ns1_values, r#"{"options": {"enabled": false}}"#).unwrap();
+            assert!(store.refresh().unwrap());
+            assert_eq!(store.load()["ns1"]["enabled"], json!(false));
+        }
+
+        #[test]
+        fn test_refresh_fires_propagation_callback() {
+            let temp_dir = TempDir::new().unwrap();
+            let base = temp_dir.path();
+            let values_file = write_ns(base, "test", "2024-01-21T18:30:00+00:00");
+
+            let events: Arc<Mutex<Vec<(String, f64)>>> = Arc::new(Mutex::new(Vec::new()));
+            let events_clone = events.clone();
+            let registry = Arc::new(SchemaRegistry::from_directory(&base.join("schemas")).unwrap());
+            let store = ValuesStore::builder(registry, &base.join("values"))
+                .with_refresh_threshold(None)
+                .with_callback(Box::new(move |ns, delay| {
+                    events_clone.lock().unwrap().push((ns.to_string(), delay));
+                }))
+                .build()
+                .unwrap();
+
+            fs::write(
+                &values_file,
+                r#"{"options": {"enabled": false}, "generated_at": "2024-01-21T19:00:00+00:00"}"#,
+            )
+            .unwrap();
+            assert!(store.refresh().unwrap());
+
+            let recorded = events.lock().unwrap();
+            assert_eq!(recorded.len(), 1);
+            assert_eq!(recorded[0].0, "test");
+        }
+
+        #[test]
+        fn test_refresh_resets_lazy_timer() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let store = ValuesStore::builder(registry, &values_dir)
+                .with_refresh_threshold(Duration::from_secs(3600))
+                .build()
+                .unwrap();
+
+            assert!(!store.refresh().unwrap());
+
+            // A rewrite within the (freshly reset) window is not picked up by
+            // reads — the manual refresh preempted the lazy refresh.
+            fs::write(
+                values_dir.join("ns1").join("values.json"),
+                r#"{"options": {"enabled": false}}"#,
+            )
+            .unwrap();
+            assert_eq!(store.load()["ns1"]["enabled"], json!(true));
+        }
+
+        #[test]
+        fn test_refresh_runs_within_staleness_window() {
+            let (_temp, schemas_dir, values_dir) = setup_store_test();
+            let registry = Arc::new(SchemaRegistry::from_directory(&schemas_dir).unwrap());
+            let store = ValuesStore::builder(registry, &values_dir)
+                .with_refresh_threshold(Duration::from_secs(3600))
+                .build()
+                .unwrap();
+
+            // Immediately after construction, well within the staleness
+            // window, a manual refresh still reloads changed files.
+            fs::write(
+                values_dir.join("ns1").join("values.json"),
+                r#"{"options": {"enabled": false}}"#,
+            )
+            .unwrap();
+            assert!(store.refresh().unwrap());
+            assert_eq!(store.load()["ns1"]["enabled"], json!(false));
         }
     }
     mod array_tests {

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -702,6 +702,26 @@ impl ValuesStoreBuilder {
 }
 
 impl ValuesStore {
+    /// Builds a store with the default configuration and performs the initial
+    /// values load synchronously.
+    ///
+    /// Use [`builder`](Self::builder) to override the configuration.
+    pub fn new(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValidationResult<Self> {
+        Self::builder(registry, values_dir).build()
+    }
+
+    /// Builds a store with a callback that fires whenever new values are detected.
+    #[deprecated(note = "use `ValuesStore::builder(...).with_callback(...)` instead")]
+    pub fn with_propagation_callback(
+        registry: Arc<SchemaRegistry>,
+        values_dir: &Path,
+        callback: PropagationCallback,
+    ) -> ValidationResult<Self> {
+        Self::builder(registry, values_dir)
+            .with_callback(callback)
+            .build()
+    }
+
     /// Returns a builder for constructing a store from the given registry and
     /// values directory.
     pub fn builder(registry: Arc<SchemaRegistry>, values_dir: &Path) -> ValuesStoreBuilder {


### PR DESCRIPTION
Previously, value reloads happened lazily inside `get()` after a 5-second staleness window. This had several downsides:

- Refresh uses synchronous file IO on the calling thread — potentially a request hot path
- In async services, this blocks the executor thread for the duration of the read and parse
- No supported way to drive a refresh manually (`get_forced` exists but has the wrong signature and is intended for testing)
- No change signal for consumers that don't interact with sentry-options directly (e.g. those maintaining derived state from option values)

### Changes

- **`Options::refresh()` / `sentry_options.refresh()`** reloads values immediately, ignoring the staleness threshold, and returns whether anything changed. Unchanged files (by mtime) are not re-read; on error the previous snapshot is retained. Every call resets the staleness timer, so calling `refresh()` more often than the threshold guarantees reads never trigger inline IO.

- **Configurable refresh threshold** via the builder in Rust or an `init` kwarg in Python. Passing `None` disables refresh-on-read entirely for consumers that take full control. Default stays _5 seconds_, exported as `DEFAULT_REFRESH_THRESHOLD`.

### Other Changes

`ValuesStore` now uses a builder similar to `InitBuilder`, replacing `::with_propagation_callback`. The previous function is still available but deprecated.