### PR TITLE
feat(cli): Adds ability to append optional suffix to configmap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ Every namespace has a mandatory `default` target (the base) plus one directory p
 
 `sentry-options-cli write` compiles one namespace/target into output in one of two formats:
 
-- `--output-format configmap` → a `ConfigMap` named `sentry-options-{namespace}` (the target is *not* in the name; each region's cluster gets its own copy). It carries a `generated_at` value plus optional `commit_sha` / `commit_timestamp` annotations.
+- `--output-format configmap` → a `ConfigMap` named `sentry-options-{namespace}` (the target is normally *not* in the name; each region's cluster gets its own copy). It carries a `generated_at` value plus optional `commit_sha` / `commit_timestamp` annotations. `--configmap-suffix {s}` appends `-{s}` for the rare case where two targets share a cluster (control-silo co-tenanted with us); the full name must be a valid DNS-1123 label, since the injector reuses it as a volume name.
 - `--output-format json` → a file `sentry-options-{namespace}-{target}.json` shaped `{"options": {...}, "generated_at": "..."}`.
 
 Generated ConfigMaps are capped just under 1 MiB; the CLI errors if a namespace exceeds it. The CD pipeline runs `write` once per namespace/target and applies per region — a namespace with no directory for a region is skipped for that region.
@@ -244,9 +244,10 @@ In production the ConfigMap is mounted by `envoy-injector`, a `MutatingWebhookCo
 ```yaml
 options.sentry.io/inject: 'true'
 options.sentry.io/namespace: seer        # comma-separated for multiple namespaces
+options.sentry.io/target: control-silo   # optional; source the sentry-options-{ns}-control-silo ConfigMap
 ```
 
-When present, the webhook patches the pod to add a volume backed by the `sentry-options-{namespace}` ConfigMap and a volumeMount at `/etc/sentry-options/values/{namespace}/`. Details worth knowing:
+When present, the webhook patches the pod to add a volume backed by the `sentry-options-{namespace}` ConfigMap (or `sentry-options-{namespace}-{target}` when `options.sentry.io/target` is set) and a volumeMount at `/etc/sentry-options/values/{namespace}/`. The `target` annotation changes only the sourced ConfigMap, not the mount path. Details worth knowing:
 
 - The webhook only fires in Kubernetes namespaces labeled `sentry-envoy-injection: enabled` (the `default` namespace carries this label, which is where most services run).
 - `failurePolicy: Fail` — if the injector is unreachable, pod creation in those namespaces fails rather than starting un-injected.

--- a/sentry-options-cli/src/main.rs
+++ b/sentry-options-cli/src/main.rs
@@ -115,6 +115,12 @@ struct WriteArgs {
         help = "target to generate ConfigMap for (required for configmap format)"
     )]
     target: Option<String>,
+
+    #[arg(
+        long,
+        help = "optional suffix appended to the ConfigMap name (e.g. `control` yields `sentry-options-<namespace>-control`). Used to disambiguate ConfigMaps that share a namespace + cluster but differ in target (e.g. control-silo co-tenanted with us)."
+    )]
+    configmap_suffix: Option<String>,
 }
 
 /// Available subcommands
@@ -266,6 +272,7 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
                 &grouped,
                 &namespace,
                 &target,
+                args.configmap_suffix.as_deref(),
                 args.commit_sha.as_deref(),
                 args.commit_timestamp.as_deref(),
                 &generated_at,
@@ -277,10 +284,7 @@ fn cli_write(args: WriteArgs, quiet: bool) -> Result<()> {
             if !quiet {
                 match out_path {
                     Some(path) => eprintln!("Successfully wrote ConfigMap to {}", path.display()),
-                    None => eprintln!(
-                        "Successfully generated ConfigMap: sentry-options-{}",
-                        namespace
-                    ),
+                    None => eprintln!("Successfully generated ConfigMap: {}", configmap.name()),
                 }
             }
         }

--- a/sentry-options-cli/src/output.rs
+++ b/sentry-options-cli/src/output.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use clap::ValueEnum;
+use sentry_options_validation::validate_k8s_name_component;
 use serde::Serialize;
 
 use crate::{AppError, FileData, NamespaceMap, OptionsMap, Result};
@@ -130,7 +131,8 @@ pub fn generate_json(maps: NamespaceMap, generated_at: &str) -> Result<Vec<(Stri
 /// in the ConfigMap name. `configmap_suffix` exists for cases where the same
 /// namespace has multiple targets deployed to the same cluster (e.g. control-silo
 /// co-tenanted with us on the internal-sentry cluster) — the caller passes a
-/// disambiguating suffix so the two ConfigMaps don't collide.
+/// disambiguating suffix so the two ConfigMaps don't collide. The assembled name
+/// is validated as a K8s DNS-1123 label and rejected up-front if invalid.
 ///
 /// # Arguments
 /// * `generated_at` - RFC3339 formatted timestamp (e.g., "2026-01-14T00:00:00Z")
@@ -147,6 +149,7 @@ pub fn generate_configmap(
         Some(suffix) => format!("sentry-options-{}-{}", namespace, suffix),
         None => format!("sentry-options-{}", namespace),
     };
+    validate_k8s_name_component(&name, "ConfigMap name")?;
 
     let options = merge_options_for_target(maps, namespace, target)?;
     let values_json = serde_json::to_string(&serde_json::json!({
@@ -356,6 +359,51 @@ mod tests {
 
         assert_eq!(cm.metadata.name, "sentry-options-getsentry-control");
         assert_eq!(cm.name(), "sentry-options-getsentry-control");
+    }
+
+    #[test]
+    fn test_generate_configmap_rejects_invalid_suffix() {
+        let maps = make_namespace_map(vec![(
+            "getsentry",
+            "default",
+            vec![("string_val", serde_json::json!("hello"))],
+        )]);
+
+        // Uppercase, underscores, and trailing hyphens would produce a name K8s rejects.
+        for bad in ["Control", "control_silo", "control-", ""] {
+            let result = generate_configmap(
+                &maps,
+                "getsentry",
+                "default",
+                Some(bad),
+                None,
+                None,
+                "2026-01-14T00:00:00Z",
+            );
+            assert!(result.is_err(), "expected suffix {:?} to be rejected", bad);
+        }
+    }
+
+    #[test]
+    fn test_generate_configmap_rejects_dotted_namespace() {
+        // A dotted namespace is a valid DNS subdomain but not a valid label, and
+        // the name is reused as a pod volume name — so it must be rejected.
+        let maps = make_namespace_map(vec![(
+            "my.ns",
+            "default",
+            vec![("string_val", serde_json::json!("hello"))],
+        )]);
+
+        let result = generate_configmap(
+            &maps,
+            "my.ns",
+            "default",
+            None,
+            None,
+            None,
+            "2026-01-14T00:00:00Z",
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/sentry-options-cli/src/output.rs
+++ b/sentry-options-cli/src/output.rs
@@ -34,6 +34,12 @@ struct ConfigMapMetadata {
     annotations: BTreeMap<String, String>,
 }
 
+impl ConfigMap {
+    pub fn name(&self) -> &str {
+        &self.metadata.name
+    }
+}
+
 struct MergedOptions {
     namespace: String,
     target: String,
@@ -117,9 +123,14 @@ pub fn generate_json(maps: NamespaceMap, generated_at: &str) -> Result<Vec<(Stri
 }
 
 /// Generate a Kubernetes ConfigMap for a specific namespace/target.
-/// Config map is of the form `sentry-options-{namespace}`.
-/// Target information is redundant to the cluster and is *not* included in the file name.
-/// Therefore, configmaps for the **same namespace** and **different targets** will have the **same** file name.
+/// Config map is of the form `sentry-options-{namespace}` by default, or
+/// `sentry-options-{namespace}-{suffix}` when `configmap_suffix` is provided.
+///
+/// Target information is normally redundant to the cluster and is *not* included
+/// in the ConfigMap name. `configmap_suffix` exists for cases where the same
+/// namespace has multiple targets deployed to the same cluster (e.g. control-silo
+/// co-tenanted with us on the internal-sentry cluster) — the caller passes a
+/// disambiguating suffix so the two ConfigMaps don't collide.
 ///
 /// # Arguments
 /// * `generated_at` - RFC3339 formatted timestamp (e.g., "2026-01-14T00:00:00Z")
@@ -127,11 +138,15 @@ pub fn generate_configmap(
     maps: &NamespaceMap,
     namespace: &str,
     target: &str,
+    configmap_suffix: Option<&str>,
     commit_sha: Option<&str>,
     commit_timestamp: Option<&str>,
     generated_at: &str,
 ) -> Result<ConfigMap> {
-    let name = format!("sentry-options-{}", namespace);
+    let name = match configmap_suffix {
+        Some(suffix) => format!("sentry-options-{}-{}", namespace, suffix),
+        None => format!("sentry-options-{}", namespace),
+    };
 
     let options = merge_options_for_target(maps, namespace, target)?;
     let values_json = serde_json::to_string(&serde_json::json!({
@@ -241,6 +256,7 @@ mod tests {
             &maps,
             "myns",
             "default",
+            None,
             Some("abc123"),
             Some("1705180800"),
             "2026-01-14T00:00:00Z",
@@ -291,6 +307,7 @@ mod tests {
             "default",
             None,
             None,
+            None,
             "2026-01-14T00:00:00Z",
         );
         assert!(result.is_err());
@@ -311,10 +328,34 @@ mod tests {
             "nonexistent",
             None,
             None,
+            None,
             "2026-01-14T00:00:00Z",
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_generate_configmap_with_suffix() {
+        let maps = make_namespace_map(vec![(
+            "getsentry",
+            "default",
+            vec![("string_val", serde_json::json!("hello"))],
+        )]);
+
+        let cm = generate_configmap(
+            &maps,
+            "getsentry",
+            "default",
+            Some("control"),
+            None,
+            None,
+            "2026-01-14T00:00:00Z",
+        )
+        .unwrap();
+
+        assert_eq!(cm.metadata.name, "sentry-options-getsentry-control");
+        assert_eq!(cm.name(), "sentry-options-getsentry-control");
     }
 
     #[test]

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -113,17 +113,31 @@ pub enum ValidationError {
     },
 }
 
-/// Validate a name component is valid for K8s (lowercase alphanumeric, '-', '.')
+/// Maximum length of a K8s DNS-1123 label (RFC 1123).
+pub const DNS1123_LABEL_MAX_LEN: usize = 63;
+
+/// Validate a name component is a valid K8s DNS-1123 label: lowercase
+/// alphanumeric and '-', starts and ends alphanumeric, at most 63 chars.
+///
+/// '.' is allowed in the configmap name, but not in `volume.name`
+/// so we reject it.
 pub fn validate_k8s_name_component(name: &str, label: &str) -> ValidationResult<()> {
+    if name.len() > DNS1123_LABEL_MAX_LEN {
+        return Err(ValidationError::InvalidName {
+            label: label.to_string(),
+            name: name.to_string(),
+            reason: format!("must be at most {} characters", DNS1123_LABEL_MAX_LEN),
+        });
+    }
     if let Some(c) = name
         .chars()
-        .find(|&c| !matches!(c, 'a'..='z' | '0'..='9' | '-' | '.'))
+        .find(|&c| !matches!(c, 'a'..='z' | '0'..='9' | '-'))
     {
         return Err(ValidationError::InvalidName {
             label: label.to_string(),
             name: name.to_string(),
             reason: format!(
-                "character '{}' not allowed. Use lowercase alphanumeric, '-', or '.'",
+                "character '{}' not allowed. Use lowercase alphanumeric or '-'",
                 c
             ),
         });
@@ -951,8 +965,8 @@ mod tests {
     fn test_validate_k8s_name_component_valid() {
         assert!(validate_k8s_name_component("relay", "namespace").is_ok());
         assert!(validate_k8s_name_component("my-service", "namespace").is_ok());
-        assert!(validate_k8s_name_component("my.service", "namespace").is_ok());
-        assert!(validate_k8s_name_component("a1-b2.c3", "namespace").is_ok());
+        assert!(validate_k8s_name_component("a1-b2-c3", "namespace").is_ok());
+        assert!(validate_k8s_name_component(&"a".repeat(63), "namespace").is_ok());
     }
 
     #[test]
@@ -982,15 +996,17 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_k8s_name_component_rejects_trailing_dot() {
-        let result = validate_k8s_name_component("service.", "namespace");
+    fn test_validate_k8s_name_component_rejects_dot() {
+        let result = validate_k8s_name_component("my.service", "namespace");
         assert!(matches!(result, Err(ValidationError::InvalidName { .. })));
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("start and end with alphanumeric")
-        );
+        assert!(result.unwrap_err().to_string().contains("'.' not allowed"));
+    }
+
+    #[test]
+    fn test_validate_k8s_name_component_rejects_too_long() {
+        let result = validate_k8s_name_component(&"a".repeat(64), "namespace");
+        assert!(matches!(result, Err(ValidationError::InvalidName { .. })));
+        assert!(result.unwrap_err().to_string().contains("at most 63"));
     }
 
     #[test]


### PR DESCRIPTION
Typically used for the target of the configmap.

Note that adding a suffix will prevent it from being automatically picked up by envoy injector. In this case, you need to make sure the injector is aware of the suffix (future PR in envoy injector).