### PR TITLE
feat(flags): In and NotIn operators now support arrays

### DIFF
--- a/clients/rust/src/features.rs
+++ b/clients/rust/src/features.rs
@@ -272,12 +272,20 @@ impl Condition {
     }
 }
 
-/// Check if a scalar context value is contained in a condition array.
+/// For scalar ctx_val, check if it's contained in the condition array.
+/// For array ctx_val, check if there is any intersection with the condition array.
 /// String comparison is case-insensitive.
 fn eval_in(ctx_val: &Value, condition_val: &Value) -> bool {
     let Some(arr) = condition_val.as_array() else {
         return false;
     };
+    match ctx_val {
+        Value::Array(ctx_arr) => ctx_arr.iter().any(|v| scalar_in(v, arr)),
+        _ => scalar_in(ctx_val, arr),
+    }
+}
+
+fn scalar_in(ctx_val: &Value, arr: &[Value]) -> bool {
     match ctx_val {
         Value::String(s) => {
             let s_lower = s.to_lowercase();
@@ -821,6 +829,52 @@ mod tests {
         let mut ctx2 = FeatureContext::new();
         ctx2.insert("organization_id", json!(999));
         assert!(!check(&opts, "organizations:test-feature", &ctx2));
+    }
+
+    #[test]
+    fn test_condition_in_list_property_matches_on_overlap() {
+        let cond = r#"{"property": "plan_family", "operator": "in", "value": ["business"]}"#;
+        let (opts, _t) = setup_feature_options(&feature_json(true, 100, cond));
+
+        let mut ctx = FeatureContext::new();
+        ctx.insert("plan_family", json!(["enterprise business", "Business"]));
+        assert!(check(&opts, "organizations:test-feature", &ctx));
+
+        let mut ctx2 = FeatureContext::new();
+        ctx2.insert("plan_family", json!(["team"]));
+        assert!(!check(&opts, "organizations:test-feature", &ctx2));
+
+        let mut ctx3 = FeatureContext::new();
+        ctx3.insert("plan_family", json!([]));
+        assert!(!check(&opts, "organizations:test-feature", &ctx3));
+    }
+
+    #[test]
+    fn test_condition_not_in_list_property_requires_no_overlap() {
+        let cond = r#"{"property": "plan_family", "operator": "not_in", "value": ["business"]}"#;
+        let (opts, _t) = setup_feature_options(&feature_json(true, 100, cond));
+
+        let mut ctx = FeatureContext::new();
+        ctx.insert("plan_family", json!(["enterprise business", "business"]));
+        assert!(!check(&opts, "organizations:test-feature", &ctx));
+
+        let mut ctx2 = FeatureContext::new();
+        ctx2.insert("plan_family", json!(["team"]));
+        assert!(check(&opts, "organizations:test-feature", &ctx2));
+    }
+
+    #[test]
+    fn test_condition_in_list_property_no_type_coercion() {
+        let cond = r#"{"property": "org_id", "operator": "in", "value": ["123"]}"#;
+        let (opts, _t) = setup_feature_options(&feature_json(true, 100, cond));
+
+        let mut ctx = FeatureContext::new();
+        ctx.insert("org_id", json!([123]));
+        assert!(!check(&opts, "organizations:test-feature", &ctx));
+
+        let int_cond = r#"{"property": "org_id", "operator": "in", "value": [123]}"#;
+        let (int_opts, _t2) = setup_feature_options(&feature_json(true, 100, int_cond));
+        assert!(check(&int_opts, "organizations:test-feature", &ctx));
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,8 @@ segments:                  # required
 
 Condition operators: `in`, `not_in`, `contains`, `not_contains`, `equals`, `not_equals`, `matches`, `not_matches`.
 
+`in` and `not_in` also accept a list-valued context property, matching when the property and the condition value share any entry. This lets a context report several names for one entity — a plan family of `["business", "enterprise business"]` matches a condition listing only `business`.
+
 ### Validation internals
 
 When a schema is loaded, `sentry-options-validation` compiles a JSON-Schema validator from it and injects two constraints (`inject_object_constraints`):


### PR DESCRIPTION
Before, the `In` and `NotIn` conditions required a scalar context. https://github.com/getsentry/sentry/pull/120636 adds a new way to use these conditions, allowing a vector (array) input. `In` will be true if the arrays have an intersection. `NotIn` will be true if the arrays have no elements in common.

This exactly matches the behaviour in the PR.

Note that there is an discrepancy where `1.0 in (1, 2)` (float <-> int comparison) returns `True` in python despite returning `false` in Rust. This will be fixed in another PR.