### PR TITLE
feat(init): Optionally load additionally schemas from memory

### DIFF
--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -25,11 +25,9 @@ refresh_threshold : float | None
     Pass ``None`` to disable refresh-on-read entirely; values then only
     change via ``refresh()``.
 schemas : dict[str, str] | None
-    Namespace schemas supplied in memory as a ``{namespace: schema_json}``
-    mapping, overlaid on top of those read from ``{dir}/schemas/`` (added
-    alongside them; errors on a namespace already present on disk). Values are
-    still loaded from disk via the fallback chain. Use when a schema is generated
-    at runtime and must coexist with on-disk schemas.
+    Namespace schemas from memory, added alongside those read from
+    ``{dir}/schemas/``, for schemas only known at runtime. Errors on a namespace
+    already on disk. Values still load from disk.
 """
 
 def refresh() -> bool: ...

--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -9,7 +9,7 @@ OptionValue = Union[_Primitive, _Object, list[Union[_Primitive, _Object]]]
 def init(
     on_propagation: Callable[[str, float], None] | None = None,
     refresh_threshold: float | None = 5.0,
-    schemas: dict[str, str] | None = None,
+    additional_schemas: dict[str, str] | None = None,
 ) -> None: ...
 """
 Initialize the options extension with schema and
@@ -24,7 +24,7 @@ refresh_threshold : float | None
     Staleness threshold in seconds for refresh-on-read (default: 5.0).
     Pass ``None`` to disable refresh-on-read entirely; values then only
     change via ``refresh()``.
-schemas : dict[str, str] | None
+additional_schemas : dict[str, str] | None
     Namespace schemas from memory, added alongside those read from
     ``{dir}/schemas/``, for schemas only known at runtime. Errors on a namespace
     already on disk. Values still load from disk.

--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -9,6 +9,7 @@ OptionValue = Union[_Primitive, _Object, list[Union[_Primitive, _Object]]]
 def init(
     on_propagation: Callable[[str, float], None] | None = None,
     refresh_threshold: float | None = 5.0,
+    schemas: dict[str, str] | None = None,
 ) -> None: ...
 """
 Initialize the options extension with schema and
@@ -23,6 +24,12 @@ refresh_threshold : float | None
     Staleness threshold in seconds for refresh-on-read (default: 5.0).
     Pass ``None`` to disable refresh-on-read entirely; values then only
     change via ``refresh()``.
+schemas : dict[str, str] | None
+    Namespace schemas supplied in memory as a ``{namespace: schema_json}``
+    mapping, overlaid on top of those read from ``{dir}/schemas/`` (added
+    alongside them; errors on a namespace already present on disk). Values are
+    still loaded from disk via the fallback chain. Use when a schema is generated
+    at runtime and must coexist with on-disk schemas.
 """
 
 def refresh() -> bool: ...

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -199,15 +199,16 @@ impl PyFeatureChecker {
 /// refresh-on-read (default: 5.0). Pass `None` to disable refresh-on-read
 /// entirely; values then only change via `refresh()`.
 ///
-/// `schemas` adds namespace schemas from memory as a `{namespace: schema_json}`
-/// mapping, alongside those read from `{dir}/schemas/`, useful for schemas only known at
-/// runtime. Errors on a namespace already on disk. Values still load from disk.
+/// `additional_schemas` adds namespace schemas from memory as a
+/// `{namespace: schema_json}` mapping, alongside those read from `{dir}/schemas/`,
+/// useful for schemas only known at runtime. Errors on a namespace already on
+/// disk. Values still load from disk.
 #[pyfunction]
-#[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64()), schemas=None))]
+#[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64()), additional_schemas=None))]
 fn init(
     on_propagation: Option<Py<PyAny>>,
     refresh_threshold: Option<f64>,
-    schemas: Option<HashMap<String, String>>,
+    additional_schemas: Option<HashMap<String, String>>,
 ) -> PyResult<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
@@ -224,7 +225,8 @@ fn init(
     };
 
     // we need to own the ones passed in
-    let owned_schemas: Vec<(String, String)> = schemas.unwrap_or_default().into_iter().collect();
+    let owned_schemas: Vec<(String, String)> =
+        additional_schemas.unwrap_or_default().into_iter().collect();
     let schema_refs: Vec<(&str, &str)> = owned_schemas
         .iter()
         .map(|(ns, json)| (ns.as_str(), json.as_str()))

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -199,11 +199,9 @@ impl PyFeatureChecker {
 /// refresh-on-read (default: 5.0). Pass `None` to disable refresh-on-read
 /// entirely; values then only change via `refresh()`.
 ///
-/// `schemas` optionally supplies namespace schemas in memory as a
-/// `{namespace: schema_json}` mapping, overlaid on top of those read from
-/// `{dir}/schemas/` (added alongside them; errors on a namespace already present
-/// on disk). Values are still loaded from disk via the fallback chain. Use this
-/// when a schema is generated at runtime and must coexist with on-disk schemas.
+/// `schemas` adds namespace schemas from memory as a `{namespace: schema_json}`
+/// mapping, alongside those read from `{dir}/schemas/`, useful for schemas only known at
+/// runtime. Errors on a namespace already on disk. Values still load from disk.
 #[pyfunction]
 #[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64()), schemas=None))]
 fn init(

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -198,9 +198,19 @@ impl PyFeatureChecker {
 /// `refresh_threshold` is the staleness threshold in seconds for
 /// refresh-on-read (default: 5.0). Pass `None` to disable refresh-on-read
 /// entirely; values then only change via `refresh()`.
+///
+/// `schemas` optionally supplies namespace schemas in memory as a
+/// `{namespace: schema_json}` mapping, overlaid on top of those read from
+/// `{dir}/schemas/` (added alongside them; errors on a namespace already present
+/// on disk). Values are still loaded from disk via the fallback chain. Use this
+/// when a schema is generated at runtime and must coexist with on-disk schemas.
 #[pyfunction]
-#[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64())))]
-fn init(on_propagation: Option<Py<PyAny>>, refresh_threshold: Option<f64>) -> PyResult<()> {
+#[pyo3(signature = (on_propagation=None, refresh_threshold=Some(DEFAULT_REFRESH_THRESHOLD.as_secs_f64()), schemas=None))]
+fn init(
+    on_propagation: Option<Py<PyAny>>,
+    refresh_threshold: Option<f64>,
+    schemas: Option<HashMap<String, String>>,
+) -> PyResult<()> {
     if GLOBAL_OPTIONS.get().is_some() {
         return Ok(());
     }
@@ -215,7 +225,17 @@ fn init(on_propagation: Option<Py<PyAny>>, refresh_threshold: Option<f64>) -> Py
         None => None,
     };
 
+    // we need to own the ones passed in
+    let owned_schemas: Vec<(String, String)> = schemas.unwrap_or_default().into_iter().collect();
+    let schema_refs: Vec<(&str, &str)> = owned_schemas
+        .iter()
+        .map(|(ns, json)| (ns.as_str(), json.as_str()))
+        .collect();
+
     let mut builder = RustOptions::builder().with_refresh_threshold(refresh_threshold);
+    if !schema_refs.is_empty() {
+        builder = builder.with_additional_schemas(&schema_refs);
+    }
     if let Some(cb) = on_propagation {
         // `Py<PyAny>` is `Send + Sync`; the closure re-acquires the GIL for the
         // call, so the callback can run on whichever thread triggers a refresh.

--- a/clients/python/tests/schemas_test.py
+++ b/clients/python/tests/schemas_test.py
@@ -1,0 +1,101 @@
+"""E2E tests for supplying namespace schemas in memory via ``init(schemas=...)``.
+
+Each test spins up a subprocess with its own ``SENTRY_OPTIONS_DIR`` so the Rust
+``OnceLock`` starts fresh and ``init(schemas=...)`` takes effect. The schema is
+passed in memory; values are still loaded from disk via the fallback chain.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import make_options_dir
+from conftest import run_isolated
+
+_SCHEMA = json.dumps(
+    {
+        'version': '1.0',
+        'type': 'object',
+        'properties': {
+            'enabled': {'type': 'boolean', 'default': False, 'description': 'Enabled'},
+        },
+    },
+)
+
+
+def _values_only_dir(tmp_path: Path) -> Path:
+    """An options dir with values for ``mem-ns`` but no schema on disk."""
+    options_dir = tmp_path / 'opts'
+    values_dir = options_dir / 'values' / 'mem-ns'
+    values_dir.mkdir(parents=True)
+    values_dir.joinpath('values.json').write_text(json.dumps({'options': {'enabled': True}}))
+    return options_dir
+
+
+def test_init_with_in_memory_schema(tmp_path: Path) -> None:
+    # No schema on disk for mem-ns; the schema comes only from init(schemas=...).
+    options_dir = _values_only_dir(tmp_path)
+    run_isolated(
+        f"""\
+        from sentry_options import init, options
+
+        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        assert options("mem-ns").get("enabled") is True
+        """,
+        options_dir,
+    )
+
+
+def test_init_with_in_memory_schema_uses_default_when_unset(tmp_path: Path) -> None:
+    options_dir = tmp_path / 'opts'
+    (options_dir / 'values').mkdir(parents=True)  # no values file for mem-ns
+    run_isolated(
+        f"""\
+        from sentry_options import init, options
+
+        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        # No value set, so the schema default from the in-memory schema is served.
+        assert options("mem-ns").get("enabled") is False
+        """,
+        options_dir,
+    )
+
+
+def test_init_overlays_in_memory_schema_on_disk_schemas(tmp_path: Path) -> None:
+    # ``make_options_dir`` writes a ``test-ns`` schema + values to disk; the
+    # in-memory ``mem-ns`` schema must be added alongside it, not replace it.
+    options_dir = make_options_dir(tmp_path)
+    mem_values = options_dir / 'values' / 'mem-ns'
+    mem_values.mkdir(parents=True)
+    mem_values.joinpath('values.json').write_text(json.dumps({'options': {'enabled': True}}))
+    run_isolated(
+        f"""\
+        from sentry_options import init, options
+
+        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        # The on-disk namespace still resolves...
+        assert options("test-ns").get("enabled") is True
+        # ...and the in-memory namespace was added alongside it.
+        assert options("mem-ns").get("enabled") is True
+        """,
+        options_dir,
+    )
+
+
+def test_init_in_memory_schema_conflicting_with_disk_errors(tmp_path: Path) -> None:
+    # ``test-ns`` already exists on disk; overlaying it in memory must error
+    # rather than silently shadow the on-disk schema.
+    options_dir = make_options_dir(tmp_path)
+    run_isolated(
+        f"""\
+        from sentry_options import init, SchemaError
+
+        try:
+            init(schemas={{"test-ns": {_SCHEMA!r}}})
+        except SchemaError:
+            pass
+        else:
+            raise AssertionError("Expected SchemaError for a namespace already on disk")
+        """,
+        options_dir,
+    )

--- a/clients/python/tests/schemas_test.py
+++ b/clients/python/tests/schemas_test.py
@@ -1,7 +1,7 @@
-"""E2E tests for supplying namespace schemas in memory via ``init(schemas=...)``.
+"""E2E tests for supplying namespace schemas in memory via ``init(additional_schemas=...)``.
 
 Each test spins up a subprocess with its own ``SENTRY_OPTIONS_DIR`` so the Rust
-``OnceLock`` starts fresh and ``init(schemas=...)`` takes effect. The schema is
+``OnceLock`` starts fresh and ``init(additional_schemas=...)`` takes effect. The schema is
 passed in memory; values are still loaded from disk via the fallback chain.
 """
 from __future__ import annotations
@@ -33,13 +33,13 @@ def _values_only_dir(tmp_path: Path) -> Path:
 
 
 def test_init_with_in_memory_schema(tmp_path: Path) -> None:
-    # No schema on disk for mem-ns; the schema comes only from init(schemas=...).
+    # No schema on disk for mem-ns; the schema comes only from init(additional_schemas=...).
     options_dir = _values_only_dir(tmp_path)
     run_isolated(
         f"""\
         from sentry_options import init, options
 
-        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        init(additional_schemas={{"mem-ns": {_SCHEMA!r}}})
         assert options("mem-ns").get("enabled") is True
         """,
         options_dir,
@@ -53,7 +53,7 @@ def test_init_with_in_memory_schema_uses_default_when_unset(tmp_path: Path) -> N
         f"""\
         from sentry_options import init, options
 
-        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        init(additional_schemas={{"mem-ns": {_SCHEMA!r}}})
         # No value set, so the schema default from the in-memory schema is served.
         assert options("mem-ns").get("enabled") is False
         """,
@@ -72,7 +72,7 @@ def test_init_overlays_in_memory_schema_on_disk_schemas(tmp_path: Path) -> None:
         f"""\
         from sentry_options import init, options
 
-        init(schemas={{"mem-ns": {_SCHEMA!r}}})
+        init(additional_schemas={{"mem-ns": {_SCHEMA!r}}})
         # The on-disk namespace still resolves...
         assert options("test-ns").get("enabled") is True
         # ...and the in-memory namespace was added alongside it.
@@ -91,7 +91,7 @@ def test_init_in_memory_schema_conflicting_with_disk_errors(tmp_path: Path) -> N
         from sentry_options import init, SchemaError
 
         try:
-            init(schemas={{"test-ns": {_SCHEMA!r}}})
+            init(additional_schemas={{"test-ns": {_SCHEMA!r}}})
         except SchemaError:
             pass
         else:

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -230,6 +230,7 @@ impl Options {
 pub struct InitBuilder<'a> {
     directory: Option<PathBuf>,
     schemas: Option<&'a [(&'a str, &'a str)]>,
+    additional_schemas: Option<&'a [(&'a str, &'a str)]>,
     callback: Option<PropagationCallback>,
     refresh_threshold: Option<Option<Duration>>,
 }
@@ -247,9 +248,17 @@ impl<'a> InitBuilder<'a> {
     }
 
     /// Provide schemas as in-memory `(namespace, json)` pairs instead of reading
-    /// them from `{dir}/schemas/`, intended to be used with `include_str!`
+    /// them from `{dir}/schemas/`, intended to be used with `include_str!`.
+    /// In other words, overrides schemas supplied locally.
     pub fn with_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
         self.schemas = Some(schemas);
+        self
+    }
+
+    /// Provide schemas as in-memory `(namespace, json)` pairs WITHOUT overriding
+    /// any local schemas in `{dir}/schemas/`. Errors on a namespace already present.
+    pub fn with_additional_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
+        self.additional_schemas = Some(schemas);
         self
     }
 
@@ -296,9 +305,23 @@ impl<'a> InitBuilder<'a> {
     pub fn build(self) -> Result<Options> {
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
-        let registry = match self.schemas {
-            Some(s) => SchemaRegistry::from_schemas(s)?,
-            None => SchemaRegistry::from_directory(&dir.join("schemas"))?,
+        let registry = match (self.schemas, self.additional_schemas) {
+            // Fully in-memory: replace the on-disk schemas entirely.
+            (Some(s), _) => SchemaRegistry::from_schemas(s)?,
+            // Overlay: base off the directory (tolerating a missing schemas dir),
+            // then add the in-memory schemas alongside it.
+            (None, Some(overrides)) => {
+                let schemas_dir = dir.join("schemas");
+                let mut registry = if schemas_dir.exists() {
+                    SchemaRegistry::from_directory(&schemas_dir)?
+                } else {
+                    SchemaRegistry::new()
+                };
+                registry.add_schemas(overrides)?;
+                registry
+            }
+            // Default: read schemas from the directory.
+            (None, None) => SchemaRegistry::from_directory(&dir.join("schemas"))?,
         };
 
         let refresh_threshold = self
@@ -442,6 +465,51 @@ mod tests {
 
         let options = Options::from_directory(temp.path()).unwrap();
         assert_eq!(options.get("test", "enabled").unwrap(), json!(true));
+    }
+
+    #[test]
+    fn test_with_additional_schemas_overlays_directory_schemas() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+
+        // On-disk namespace.
+        create_schema(&schemas, "disk", BOOL_SCHEMA);
+        create_values(&values, "disk", r#"{"options": {"enabled": true}}"#);
+        // In-memory namespace: schema via with_additional_schemas, values on disk.
+        create_values(&values, "mem", r#"{"options": {"enabled": true}}"#);
+
+        let options = Options::builder()
+            .with_directory(temp.path())
+            .with_additional_schemas(&[("mem", BOOL_SCHEMA)])
+            .build()
+            .unwrap();
+
+        // The on-disk namespace still resolves...
+        assert_eq!(options.get("disk", "enabled").unwrap(), json!(true));
+        // ...and the in-memory namespace was added alongside it.
+        assert_eq!(options.get("mem", "enabled").unwrap(), json!(true));
+    }
+
+    #[test]
+    fn test_with_additional_schemas_conflicting_namespace_errors() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(&schemas, "dup", BOOL_SCHEMA);
+
+        // Overlaying a namespace that already exists on disk must error rather
+        // than silently shadow it.
+        let result = Options::builder()
+            .with_directory(temp.path())
+            .with_additional_schemas(&[("dup", BOOL_SCHEMA)])
+            .build();
+
+        assert!(
+            result.is_err(),
+            "expected an error for a namespace already on disk"
+        );
     }
 
     #[test]

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -222,6 +222,8 @@ impl Options {
 /// All settings are optional and independent:
 /// - `with_directory` overrides the base directory
 /// - `with_schemas` supplies schemas in memory instead of reading `{dir}/schemas/`
+/// - `with_additional_schemas` layers in-memory schemas on top of the base chosen
+///   above, whether that base came from disk or from `with_schemas`
 /// - `with_callback` registers a callback that fires on every value refresh.
 /// - `with_refresh_threshold` overrides or disables the staleness threshold
 ///   for refresh-on-read.
@@ -257,6 +259,10 @@ impl<'a> InitBuilder<'a> {
 
     /// Provide schemas as in-memory `(namespace, json)` pairs WITHOUT overriding
     /// any local schemas in `{dir}/schemas/`. Errors on a namespace already present.
+    ///
+    /// Composes with [`with_schemas`](Self::with_schemas): these are layered on
+    /// top of whatever base that selects, so setting both replaces the on-disk
+    /// schemas and then adds these alongside the replacements.
     pub fn with_additional_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
         self.additional_schemas = Some(schemas);
         self
@@ -305,24 +311,25 @@ impl<'a> InitBuilder<'a> {
     pub fn build(self) -> Result<Options> {
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
-        let registry = match (self.schemas, self.additional_schemas) {
-            // Fully in-memory: replace the on-disk schemas entirely.
-            (Some(s), _) => SchemaRegistry::from_schemas(s)?,
-            // Overlay: base off the directory (tolerating a missing schemas dir),
-            // then add the in-memory schemas alongside it.
-            (None, Some(overrides)) => {
+        // `with_schemas` picks the base registry, `with_additional_schemas` layers
+        // on top of whichever base that is.
+        let mut registry = match self.schemas {
+            Some(s) => SchemaRegistry::from_schemas(s)?,
+            None => {
                 let schemas_dir = dir.join("schemas");
-                let mut registry = if schemas_dir.exists() {
-                    SchemaRegistry::from_directory(&schemas_dir)?
-                } else {
+                // With additional schemas supplied, a missing schemas dir just means
+                // there is nothing on disk to layer onto. Without them it stays an
+                // error: a caller who supplied no schemas at all has none.
+                if self.additional_schemas.is_some() && !schemas_dir.exists() {
                     SchemaRegistry::new()
-                };
-                registry.add_schemas(overrides)?;
-                registry
+                } else {
+                    SchemaRegistry::from_directory(&schemas_dir)?
+                }
             }
-            // Default: read schemas from the directory.
-            (None, None) => SchemaRegistry::from_directory(&dir.join("schemas"))?,
         };
+        if let Some(additional) = self.additional_schemas {
+            registry.add_schemas(additional)?;
+        }
 
         let refresh_threshold = self
             .refresh_threshold
@@ -490,6 +497,31 @@ mod tests {
         assert_eq!(options.get("disk", "enabled").unwrap(), json!(true));
         // ...and the in-memory namespace was added alongside it.
         assert_eq!(options.get("mem", "enabled").unwrap(), json!(true));
+    }
+
+    #[test]
+    fn test_with_schemas_and_additional_schemas_compose() {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        let values = temp.path().join("values");
+        fs::create_dir_all(&schemas).unwrap();
+
+        // On disk but replaced by with_schemas, so it must NOT resolve.
+        create_schema(&schemas, "disk", BOOL_SCHEMA);
+        create_values(&values, "disk", r#"{"options": {"enabled": true}}"#);
+        create_values(&values, "base", r#"{"options": {"enabled": true}}"#);
+        create_values(&values, "extra", r#"{"options": {"enabled": true}}"#);
+
+        let options = Options::builder()
+            .with_directory(temp.path())
+            .with_schemas(&[("base", BOOL_SCHEMA)])
+            .with_additional_schemas(&[("extra", BOOL_SCHEMA)])
+            .build()
+            .unwrap();
+
+        assert_eq!(options.get("base", "enabled").unwrap(), json!(true));
+        assert_eq!(options.get("extra", "enabled").unwrap(), json!(true));
+        assert!(options.get("disk", "enabled").is_err());
     }
 
     #[test]

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -222,8 +222,7 @@ impl Options {
 /// All settings are optional and independent:
 /// - `with_directory` overrides the base directory
 /// - `with_schemas` supplies schemas in memory instead of reading `{dir}/schemas/`
-/// - `with_additional_schemas` layers in-memory schemas on top of the base chosen
-///   above, whether that base came from disk or from `with_schemas`
+/// - `with_additional_schemas` adds in-memory schemas alongside whichever base the above selects
 /// - `with_callback` registers a callback that fires on every value refresh.
 /// - `with_refresh_threshold` overrides or disables the staleness threshold
 ///   for refresh-on-read.
@@ -257,12 +256,9 @@ impl<'a> InitBuilder<'a> {
         self
     }
 
-    /// Provide schemas as in-memory `(namespace, json)` pairs WITHOUT overriding
-    /// any local schemas in `{dir}/schemas/`. Errors on a namespace already present.
-    ///
-    /// Composes with [`with_schemas`](Self::with_schemas): these are layered on
-    /// top of whatever base that selects, so setting both replaces the on-disk
-    /// schemas and then adds these alongside the replacements.
+    /// Add in-memory `(namespace, json)` schemas alongside the base regardless
+    /// if it came from `{dir}/schemas/` or [`with_schemas`](Self::with_schemas).
+    /// Errors on a namespace the base already has, rather than shadowing it.
     pub fn with_additional_schemas(mut self, schemas: &'a [(&'a str, &'a str)]) -> Self {
         self.additional_schemas = Some(schemas);
         self
@@ -311,15 +307,13 @@ impl<'a> InitBuilder<'a> {
     pub fn build(self) -> Result<Options> {
         let dir = self.directory.unwrap_or_else(resolve_options_dir);
 
-        // `with_schemas` picks the base registry, `with_additional_schemas` layers
-        // on top of whichever base that is.
+        // `with_schemas` picks the base, `with_additional_schemas` adds to it.
         let mut registry = match self.schemas {
             Some(s) => SchemaRegistry::from_schemas(s)?,
             None => {
                 let schemas_dir = dir.join("schemas");
-                // With additional schemas supplied, a missing schemas dir just means
-                // there is nothing on disk to layer onto. Without them it stays an
-                // error: a caller who supplied no schemas at all has none.
+                // A missing dir is only tolerable when in-memory schemas will fill
+                // the registry; otherwise the caller ends up with nothing.
                 if self.additional_schemas.is_some() && !schemas_dir.exists() {
                     SchemaRegistry::new()
                 } else {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ Options must be initialized once at startup, guarded by a global `OnceLock`. Rus
 | `.with_callback(cb)` | Register a reload callback |
 | `.with_refresh_threshold(t)` | Override the refresh-on-read staleness threshold (default 5 s); `None` disables refresh-on-read |
 
-`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None, refresh_threshold=5.0, schemas=None)`, where `schemas` is a `{ns: json}` mapping equivalent to `.with_additional_schemas()`.
+`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None, refresh_threshold=5.0, additional_schemas=None)`, where `additional_schemas` is a `{ns: json}` mapping equivalent to `.with_additional_schemas()`.
 
 The `init()` shorthand and Python's `init()` are idempotent — calling again is a no-op. The builder's `.init()` instead returns `OptionsError::AlreadyInitialized` when options are already initialized, so re-initializing with different settings is a loud error rather than a silent no-op.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,10 +180,11 @@ Options must be initialized once at startup, guarded by a global `OnceLock`. Rus
 | _(no overrides)_ | Resolve the directory and load schemas from disk |
 | `.with_directory(path)` | Load schemas and values from a specific base directory |
 | `.with_schemas(&[(ns, json)])` | Use schemas embedded in the binary via `include_str!`. values still load from disk |
+| `.with_additional_schemas(&[(ns, json)])` | Add in-memory schemas alongside the base above, for schemas only known at runtime. Errors on a namespace the base already has |
 | `.with_callback(cb)` | Register a reload callback |
 | `.with_refresh_threshold(t)` | Override the refresh-on-read staleness threshold (default 5 s); `None` disables refresh-on-read |
 
-`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None, refresh_threshold=5.0)`.
+`init()` is a shorthand for `Options::builder().init()`; the standalone `init_with_schemas` / `init_with_propagation_callback` functions are deprecated in favor of the builder. Python: `init(on_propagation=None, refresh_threshold=5.0, schemas=None)`, where `schemas` is a `{ns: json}` mapping equivalent to `.with_additional_schemas()`.
 
 The `init()` shorthand and Python's `init()` are idempotent — calling again is a no-op. The builder's `.init()` instead returns `OptionsError::AlreadyInitialized` when options are already initialized, so re-initializing with different settings is a loud error rather than a silent no-op.
 

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -297,9 +297,18 @@ impl SchemaRegistry {
     /// pipeline as `from_directory` (meta-schema check, constraint injection,
     /// validator compilation) without reading from the filesystem.
     pub fn from_schemas(schemas: &[(&str, &str)]) -> ValidationResult<Self> {
+        let mut registry = Self::new();
+        registry.add_schemas(schemas)?;
+        Ok(registry)
+    }
+
+    /// Add in-memory `(namespace, json)` schemas to this registry, overlaying
+    /// whatever is already loaded (e.g. from a directory). Applies the same
+    /// validation pipeline as `from_directory`. Errors if a namespace is already
+    /// present, so an in-memory schema can't silently shadow one loaded from disk.
+    pub fn add_schemas(&mut self, schemas: &[(&str, &str)]) -> ValidationResult<()> {
         let namespace_validator = Self::compile_namespace_validator()?;
         let schema_file = Path::new("<embedded>");
-        let mut schemas_map = HashMap::new();
 
         for (namespace, json) in schemas {
             validate_k8s_name_component(namespace, "namespace name")?;
@@ -312,7 +321,7 @@ impl SchemaRegistry {
 
             Self::validate_with_namespace_schema(&schema_data, schema_file, &namespace_validator)?;
             let schema = Self::parse_schema(schema_data, namespace, schema_file)?;
-            if schemas_map.insert(namespace.to_string(), schema).is_some() {
+            if self.schemas.insert(namespace.to_string(), schema).is_some() {
                 return Err(ValidationError::SchemaError {
                     file: schema_file.to_path_buf(),
                     message: format!("Duplicate namespace '{}'", namespace),
@@ -320,9 +329,7 @@ impl SchemaRegistry {
             }
         }
 
-        Ok(Self {
-            schemas: schemas_map,
-        })
+        Ok(())
     }
 
     /// Validate an entire values object for a namespace

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -302,10 +302,9 @@ impl SchemaRegistry {
         Ok(registry)
     }
 
-    /// Add in-memory `(namespace, json)` schemas to this registry, overlaying
-    /// whatever is already loaded (e.g. from a directory). Applies the same
-    /// validation pipeline as `from_directory`. Errors if a namespace is already
-    /// present, so an in-memory schema can't silently shadow one loaded from disk.
+    /// Add in-memory `(namespace, json)` schemas to whatever is already loaded.
+    /// Errors on an already-present namespace, so an in-memory schema can't
+    /// silently shadow one loaded from disk.
     pub fn add_schemas(&mut self, schemas: &[(&str, &str)]) -> ValidationResult<()> {
         let namespace_validator = Self::compile_namespace_validator()?;
         let schema_file = Path::new("<embedded>");


### PR DESCRIPTION
This work is for the sentry/getsentry feature flag migration.

`init()` loads schemas from disk (i.e. ~/sentry-options/schemas/...), but you can now also optionally supply in memory schemas in ADDITION to the ones loaded from disk. These namespaces must be unique or else we will error.

### Why?

Feature flag management in sentry/getsentry has a lot of extra functionality, so we aren't gonna get rid of `manager.add`. Instead, we have `manager.add` (and by extension, `default_manager.flagpole_features`), be the source of truth. So the plan is to generate the schema from the manager, then load it into the schema under a different namespace, probably `getsentry-features`.