### PR TITLE
feat(flags): Expose feature flag definition helper

### DIFF
--- a/clients/python/python/sentry_options/__init__.py
+++ b/clients/python/python/sentry_options/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Union
 
+from sentry_options._core import feature_property
 from sentry_options._core import FeatureChecker
 from sentry_options._core import FeatureContext
 from sentry_options._core import features
@@ -26,8 +27,10 @@ _Primitive = Union[str, int, float, bool]
 _Object = dict[str, _Primitive]
 OptionValue = Union[_Primitive, _Object, list[Union[_Primitive, _Object]]]
 
+
 __all__ = [
     'init',
+    'feature_property',
     'features',
     'FeatureChecker',
     'FeatureContext',

--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -25,6 +25,12 @@ refresh_threshold : float | None
     change via ``refresh()``.
 """
 
+def feature_property() -> dict[str, str]: ...
+"""
+Return the value a namespace schema pairs with each ``feature.<name>`` key,
+i.e. ``{"$ref": "#/definitions/Feature"}``, for assembling a schema in memory.
+"""
+
 def refresh() -> bool: ...
 """
 Refresh values from disk, ignoring the staleness threshold.

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -250,6 +250,13 @@ fn refresh(py: Python<'_>) -> PyResult<bool> {
     py.detach(|| opts.refresh()).map_err(options_err)
 }
 
+/// Return the value a namespace schema pairs with each ``feature.<name>`` key,
+/// i.e. ``{"$ref": "#/definitions/Feature"}``, for assembling a schema in memory.
+#[pyfunction]
+fn feature_property(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    json_to_py(py, &sentry_options::feature_property())
+}
+
 /// Get a namespace handle for accessing options.
 ///
 /// Raises RuntimeError if init() has not been called.
@@ -362,6 +369,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(options, m)?)?;
     m.add_function(wrap_pyfunction!(features, m)?)?;
     m.add_function(wrap_pyfunction!(refresh, m)?)?;
+    m.add_function(wrap_pyfunction!(feature_property, m)?)?;
     // Classes
     m.add_class::<NamespaceOptions>()?;
     m.add_class::<PyFeatureContext>()?;

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-pub use sentry_options_validation::{DEFAULT_REFRESH_THRESHOLD, PropagationCallback};
+pub use sentry_options_validation::{
+    DEFAULT_REFRESH_THRESHOLD, PropagationCallback, feature_property,
+};
 use sentry_options_validation::{
     SchemaRegistry, ValidationError, ValuesStore, resolve_options_dir,
 };

--- a/sentry-options-validation/src/lib.rs
+++ b/sentry-options-validation/src/lib.rs
@@ -154,6 +154,13 @@ pub fn validate_k8s_name_component(name: &str, label: &str) -> ValidationResult<
     Ok(())
 }
 
+/// The value a namespace schema pairs with each `feature.<name>` key, i.e.
+/// `{"$ref": "#/definitions/Feature"}`. Splice this in when assembling a schema
+/// in memory rather than hand-rolling the ref the meta-schema requires.
+pub fn feature_property() -> Value {
+    json!({ "$ref": "#/definitions/Feature" })
+}
+
 /// Metadata for a single option in a namespace schema
 #[derive(Debug, Clone)]
 pub struct OptionMetadata {
@@ -979,6 +986,18 @@ mod tests {
         fs::write(&values_file, values_json).unwrap();
 
         (schemas_dir, values_dir)
+    }
+
+    #[test]
+    fn test_feature_property_matches_meta_schema() {
+        // Fails if the shape drifts from what the meta-schema requires.
+        let schema = json!({
+            "version": "1.0",
+            "type": "object",
+            "properties": { "feature.red-bar": feature_property() },
+        })
+        .to_string();
+        SchemaRegistry::from_schemas(&[("getsentry-features", &schema)]).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
`getsentry` is going to manually create a feature flag schema json in memory. In order to not have the feature definition live in 2 repos, we have our source of truth here and expose it as a helper.

The idea is, `getsentry` will have some sort of `for` loop with
```py
schema = json.dumps({"properties":f"{feature_flag}: {feature_property()}"}) 
init(..., schemas=schema)
```