### PR TITLE
ci: Replace secrets: inherit with explicit secret in validate-schema-changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,8 @@ jobs:
     name: Validate Schema Changes
     needs: check-cli-changes
     uses: ./.github/workflows/validate-schema.yml
-    secrets: inherit
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:
       schemas-path: sentry-options/schemas
       build-from-source: ${{ needs.check-cli-changes.outputs.build-from-source == 'true' }}


### PR DESCRIPTION
## Summary
- `main.yml`'s `validate-schema-changes` job used `secrets: inherit` when calling the local `validate-schema.yml` reusable workflow, exposing every repository secret to it.
- `validate-schema.yml` declares exactly one optional secret under `workflow_call.secrets`: `SENTRY_INTERNAL_APP_PRIVATE_KEY`, used only when a schema deletion is detected (to check out `sentry-options-automator`).
- Replaced `secrets: inherit` with an explicit map passing only that secret.

## Test plan
- [x] Confirmed `validate-schema.yml` declares only `SENTRY_INTERNAL_APP_PRIVATE_KEY` under `workflow_call.secrets`
- [x] Validated workflow YAML parses correctly
- [ ] Verify the Validate Schema Changes check still runs correctly on this PR

Fixes VULN-2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)