### PR TITLE
feat(flags): Add `try_has`, which doesn't swallow failures into `false`

### DIFF
--- a/clients/python/python/sentry_options/_core.pyi
+++ b/clients/python/python/sentry_options/_core.pyi
@@ -73,6 +73,14 @@ class FeatureChecker:
     """
     def has(self, feature_name: str, context: FeatureContext) -> bool:
         """Check if a feature flag with `feature_name` is available to `context`"""
+    def try_has(self, feature_name: str, context: FeatureContext) -> bool | None:
+        """
+        Same as ``has``, but will return ``None`` if the feature has no value
+        set, or one of ``NotInitializedError``, ``UnknownNamespaceError``,
+        or ``SchemaError`` during a failure.
+
+        The latter return values would all have been swallowed into ``false`` in ``has``.
+        """
     def __repr__(self) -> str: ...
 
 

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 
 use ::sentry_options::{
     DEFAULT_REFRESH_THRESHOLD, FeatureChecker as RustFeatureChecker,
-    FeatureContext as RustFeatureContext, Options as RustOptions, OptionsError as RustOptionsError,
+    FeatureContext as RustFeatureContext, FeatureError as RustFeatureError, Options as RustOptions,
+    OptionsError as RustOptionsError,
 };
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -132,6 +133,19 @@ fn options_err(err: RustOptionsError) -> PyErr {
     }
 }
 
+fn feature_err(err: RustFeatureError) -> PyErr {
+    match err {
+        RustFeatureError::NotInitialized => {
+            NotInitializedError::new_err("Options not initialized - call init() first")
+        }
+        // feature flag values are basically schemas
+        RustFeatureError::InvalidValue { ref key } => {
+            SchemaError::new_err(format!("Value for '{}' is not a valid feature", key))
+        }
+        RustFeatureError::Options(e) => options_err(e),
+    }
+}
+
 /// Feature evaluation context holding arbitrary key-value data.
 ///
 /// Pass a dict of context data and optional identity_fields to control
@@ -181,6 +195,19 @@ impl PyFeatureChecker {
     /// Returns false if the feature is not defined, not enabled, or conditions don't match.
     fn has(&self, feature_name: &str, context: PyRef<'_, PyFeatureContext>) -> bool {
         self.inner.has(feature_name, &context.inner)
+    }
+
+    /// Like `has`, but returns a Result<Option<bool>> instead.
+    /// Instead of swallowing all failures into `false`, will return
+    /// `None` if no value is defined, and an `Err` for an error.
+    fn try_has(
+        &self,
+        feature_name: &str,
+        context: PyRef<'_, PyFeatureContext>,
+    ) -> PyResult<Option<bool>> {
+        self.inner
+            .try_has(feature_name, &context.inner)
+            .map_err(feature_err)
     }
 
     fn __repr__(&self) -> String {

--- a/clients/python/tests/features_test.py
+++ b/clients/python/tests/features_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from sentry_options import FeatureContext
 from sentry_options import features
+from sentry_options import UnknownNamespaceError
 
 
 NAMESPACE = 'sentry-options-testing'
@@ -174,3 +175,32 @@ def test_feature_context_bool_not_confused_with_int() -> None:
 def test_invalid_context_value_type_raises() -> None:
     with pytest.raises((TypeError, ValueError)):
         make_context({'key': object()})
+
+
+def test_try_has_normal_case_matches_has() -> None:
+    ctx = make_context({'organization_id': 123})
+    checker = features(NAMESPACE)
+
+    assert checker.try_has('organizations:enabled-feature', ctx) is checker.has('organizations:enabled-feature', ctx)
+    assert checker.try_has('organizations:disabled-feature', ctx) is checker.has('organizations:disabled-feature', ctx)
+
+
+def test_try_has_returns_none_when_feature_has_no_value() -> None:
+    ctx = make_context({'organization_id': 123})
+    checker = features(NAMESPACE)
+
+    # try_has() returns None...
+    assert checker.try_has('organizations:nonexistent', ctx) is None
+    # has() returns false for this case
+    assert checker.has('organizations:nonexistent', ctx) is False
+
+
+def test_try_has_raises_on_unknown_namespace() -> None:
+    ctx = make_context({'organization_id': 123})
+
+    # try_has() raises...
+    with pytest.raises(UnknownNamespaceError):
+        features('not-a-namespace').try_has('organizations:enabled-feature', ctx)
+
+    # ...white has() returns false for this case
+    assert features('not-a-namespace').has('organizations:enabled-feature', ctx) is False

--- a/clients/rust/src/features.rs
+++ b/clients/rust/src/features.rs
@@ -434,6 +434,21 @@ fn eval_matches(ctx_val: Option<&Value>, condition_val: &Value) -> Option<bool> 
 }
 
 /// A handle for checking feature flags within a specific namespace.
+/// Why a feature could not be evaluated. Distinct from [`crate::OptionsError`]:
+/// an unset feature is not an error here (see [`FeatureChecker::try_has`]), and a
+/// value that fails to parse as a `Feature` is.
+#[derive(Debug, thiserror::Error)]
+pub enum FeatureError {
+    #[error("Options not initialized - call init() first")]
+    NotInitialized,
+
+    #[error("Value for '{key}' is not a valid feature")]
+    InvalidValue { key: String },
+
+    #[error(transparent)]
+    Options(#[from] crate::OptionsError),
+}
+
 pub struct FeatureChecker {
     namespace: String,
     options: Option<&'static crate::Options>,
@@ -452,29 +467,43 @@ impl FeatureChecker {
     /// Returns false if the feature is not defined, not enabled, conditions don't match,
     /// or options have not been initialized.
     pub fn has(&self, feature_name: &str, context: &FeatureContext) -> bool {
-        let Some(opts) = self.options else {
-            return false;
-        };
+        // Deliberately collapses every failure to false, use `try_has` when the distinction matters.
+        match self.try_has(feature_name, context) {
+            Ok(Some(result)) => result,
+            Ok(None) => false,
+            Err(e) => {
+                tracing::debug!(feature = feature_name, error = %e, "Feature evaluation failed");
+                false
+            }
+        }
+    }
+
+    /// Like [`has`](Self::has), but distinguishes a feature that evaluated to false
+    /// from one that could not be evaluated at all.
+    ///
+    /// - `Ok(Some(bool))` -- evaluated: disabled, no matching segment, or matched
+    /// - `Ok(None)` -- no value set for this feature, so there was nothing to evaluate
+    /// - `Err(_)` -- evaluation failed: see [`FeatureError`]
+    ///
+    /// Prefer `has` on hot paths.
+    pub fn try_has(
+        &self,
+        feature_name: &str,
+        context: &FeatureContext,
+    ) -> Result<Option<bool>, FeatureError> {
+        let opts = self.options.ok_or(FeatureError::NotInitialized)?;
         let key = format!("feature.{feature_name}");
 
         let feature_val = match opts.get(&self.namespace, &key) {
             Ok(v) => v,
-            Err(e) => {
-                tracing::debug!(key = %key, error = %e, "Failed to get feature");
-                return false;
-            }
+            // A feature the schema knows about but that has no value set is absent,
+            // not an error: nothing has been rolled out yet.
+            Err(crate::OptionsError::UnknownOption { .. }) => return Ok(None),
+            Err(e) => return Err(e.into()),
         };
 
-        let feature = match Feature::from_json(&feature_val) {
-            Some(f) => {
-                tracing::debug!(key = %key, "Parsed feature");
-                f
-            }
-            None => {
-                tracing::debug!(key = %key, "Failed to parse feature");
-                return false;
-            }
-        };
+        let feature = Feature::from_json(&feature_val)
+            .ok_or_else(|| FeatureError::InvalidValue { key: key.clone() })?;
 
         let result = feature.matches(context);
         tracing::debug!(
@@ -483,7 +512,7 @@ impl FeatureChecker {
             context_id = context.id(),
             "Feature match result"
         );
-        result
+        Ok(Some(result))
     }
 }
 
@@ -1576,5 +1605,102 @@ mod tests {
 
         // A usable list that lacks the value still matches when negated.
         assert!(condition_matches("not_contains", r#""a""#, &list));
+    }
+
+    /// FeatureChecker holds a `&'static Options`, so tests leak one.
+    fn checker(opts: Options, namespace: &str) -> FeatureChecker {
+        FeatureChecker::new(namespace.to_string(), Box::leak(Box::new(opts)))
+    }
+
+    /// Schema declaring the feature, with a values file that sets nothing.
+    fn setup_without_value() -> (Options, TempDir) {
+        let temp = TempDir::new().unwrap();
+        let schemas = temp.path().join("schemas");
+        fs::create_dir_all(&schemas).unwrap();
+        create_schema(&schemas, "test", FEATURE_SCHEMA);
+        create_values(&temp.path().join("values"), "test", r#"{"options": {}}"#);
+        (Options::from_directory(temp.path()).unwrap(), temp)
+    }
+
+    #[test]
+    fn test_try_has_evaluated() {
+        let (opts, _temp) = setup_feature_options(&feature_json(true, 100, ""));
+        let checker = checker(opts, "test");
+
+        let result = checker.try_has("organizations:test-feature", &FeatureContext::new());
+        assert_eq!(result.unwrap(), Some(true));
+    }
+
+    #[test]
+    fn test_try_has_evaluated_false_is_not_absent() {
+        // A disabled feature evaluated fine; it just isn't on. This is the case a
+        // bare bool conflates with "could not evaluate".
+        let (opts, _temp) = setup_feature_options(&feature_json(false, 100, ""));
+        let checker = checker(opts, "test");
+
+        let result = checker.try_has("organizations:test-feature", &FeatureContext::new());
+        assert_eq!(result.unwrap(), Some(false));
+    }
+
+    #[test]
+    fn test_try_has_absent_when_no_value_set() {
+        let (opts, _temp) = setup_without_value();
+        let checker = checker(opts, "test");
+
+        let result = checker.try_has("organizations:test-feature", &FeatureContext::new());
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_try_has_absent_when_feature_not_in_schema() {
+        let (opts, _temp) = setup_feature_options(&feature_json(true, 100, ""));
+        let checker = checker(opts, "test");
+
+        let result = checker.try_has("organizations:never-declared", &FeatureContext::new());
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_try_has_errors_on_unknown_namespace() {
+        let (opts, _temp) = setup_feature_options(&feature_json(true, 100, ""));
+        let checker = checker(opts, "not-a-namespace");
+
+        assert!(matches!(
+            checker.try_has("organizations:test-feature", &FeatureContext::new()),
+            Err(FeatureError::Options(
+                crate::OptionsError::UnknownNamespace(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_try_has_errors_when_uninitialized() {
+        let checker = FeatureChecker {
+            namespace: "test".to_string(),
+            options: None,
+        };
+
+        assert!(matches!(
+            checker.try_has("organizations:test-feature", &FeatureContext::new()),
+            Err(FeatureError::NotInitialized)
+        ));
+    }
+
+    #[test]
+    fn test_has_still_collapses_every_failure_to_false() {
+        // has() is the fail-soft read path and must not start propagating.
+        let (opts, _temp) = setup_without_value();
+        let absent = checker(opts, "test");
+        assert!(!absent.has("organizations:test-feature", &FeatureContext::new()));
+
+        let (opts, _temp) = setup_feature_options(&feature_json(true, 100, ""));
+        let unknown_ns = checker(opts, "not-a-namespace");
+        assert!(!unknown_ns.has("organizations:test-feature", &FeatureContext::new()));
+
+        let uninitialized = FeatureChecker {
+            namespace: "test".to_string(),
+            options: None,
+        };
+        assert!(!uninitialized.has("organizations:test-feature", &FeatureContext::new()));
     }
 }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub mod features;
 
-pub use features::{FeatureChecker, FeatureContext, features};
+pub use features::{FeatureChecker, FeatureContext, FeatureError, features};
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};


### PR DESCRIPTION
Normally we would want `has` to just return `true` or `false`. However, for the purposes of the divergence checking, we want to see exceptions, nones, and normal failures.

This adds a `try_has`, really only meant to be used during the migration, which returns `Result<Option<bool>>` instead of just `bool`.

`Some(bool)` - The flag exists, it's value exists, and it was evaluated as `true` or `false` (includes the global disable)
`None` - The flag exists, but has no value definition in the configmap
`Err` - The flag encountered some sort of error, perhaps the namespace doesn't exist, the flag doesn't exist, or the values in the configmap are invalid